### PR TITLE
Populate created_at and last_updated_at fields

### DIFF
--- a/src/main/kotlin/no/ssb/metadata/models/InputVariableDefinition.kt
+++ b/src/main/kotlin/no/ssb/metadata/models/InputVariableDefinition.kt
@@ -14,6 +14,7 @@ import no.ssb.metadata.constants.*
 import no.ssb.metadata.vardef.integrations.klass.validators.KlassCode
 import java.net.URL
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Suppress("ktlint:standard:annotation", "ktlint:standard:indent") // ktlint disagrees with the formatter
 @Serdeable(naming = SnakeCaseStrategy::class)
@@ -98,12 +99,12 @@ data class InputVariableDefinition(
             // TODO depends on authentication to make user information available
             owner = null,
             contact = contact,
-            // TODO
-            createdAt = "",
+            // Provide a placeholder value, actual value set by data layer
+            createdAt = LocalDateTime.now(),
             // TODO depends on authentication to make user information available
             createdBy = null,
-            // TODO
-            lastUpdatedAt = "",
+            // Provide a placeholder value, actual value set by data layer
+            lastUpdatedAt = LocalDateTime.now(),
             // TODO depends on authentication to make user information available
             lastUpdatedBy = null,
         )

--- a/src/main/kotlin/no/ssb/metadata/models/RenderedVariableDefinition.kt
+++ b/src/main/kotlin/no/ssb/metadata/models/RenderedVariableDefinition.kt
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import no.ssb.metadata.constants.RENDERED_VARIABLE_DEFINITION_EXAMPLE
 import java.net.URL
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @Schema(
     example = RENDERED_VARIABLE_DEFINITION_EXAMPLE,
@@ -29,8 +30,8 @@ data class RenderedVariableDefinition(
     val relatedVariableDefinitionUris: List<URL>?,
     val owner: Owner?,
     val contact: RenderedContact,
-    val createdAt: String,
+    val createdAt: LocalDateTime,
     val createdBy: Person?,
-    val lastUpdatedAt: String,
+    val lastUpdatedAt: LocalDateTime,
     val lastUpdatedBy: Person?,
 )

--- a/src/main/kotlin/no/ssb/metadata/models/SavedVariableDefinition.kt
+++ b/src/main/kotlin/no/ssb/metadata/models/SavedVariableDefinition.kt
@@ -1,14 +1,13 @@
 package no.ssb.metadata.models
 
 import io.micronaut.core.annotation.Nullable
-import io.micronaut.data.annotation.GeneratedValue
-import io.micronaut.data.annotation.Id
-import io.micronaut.data.annotation.MappedEntity
+import io.micronaut.data.annotation.*
 import io.micronaut.data.model.naming.NamingStrategies
 import org.bson.types.ObjectId
 import java.net.URI
 import java.net.URL
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 @MappedEntity(namingStrategy = NamingStrategies.Raw::class)
 data class SavedVariableDefinition(
@@ -37,10 +36,12 @@ data class SavedVariableDefinition(
     @Nullable
     var owner: Owner?,
     var contact: Contact,
-    var createdAt: String,
+    @DateCreated
+    var createdAt: LocalDateTime,
     @Nullable
     var createdBy: Person?,
-    var lastUpdatedAt: String,
+    @DateUpdated
+    var lastUpdatedAt: LocalDateTime,
     @Nullable
     var lastUpdatedBy: Person?,
 ) {

--- a/src/test/kotlin/no/ssb/metadata/VariableDefinitionByIdControllerTest.kt
+++ b/src/test/kotlin/no/ssb/metadata/VariableDefinitionByIdControllerTest.kt
@@ -8,13 +8,15 @@ import io.viascom.nanoid.NanoId
 import no.ssb.metadata.models.InputVariableDefinition
 import no.ssb.metadata.models.SupportedLanguages
 import no.ssb.metadata.utils.BaseVardefTest
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import java.time.temporal.ChronoUnit
 
 class VariableDefinitionByIdControllerTest : BaseVardefTest() {
     @Test
@@ -59,7 +61,7 @@ class VariableDefinitionByIdControllerTest : BaseVardefTest() {
             .then()
             .statusCode(204)
             .header("Content-Type", nullValue())
-        Assertions.assertThat(variableDefinitionService.listAll()).doesNotContain(SAVED_VARIABLE_DEFINITION)
+        assertThat(variableDefinitionService.listAll().map { it.definitionId }).doesNotContain(SAVED_VARIABLE_DEFINITION.definitionId)
     }
 
     @Test
@@ -70,7 +72,6 @@ class VariableDefinitionByIdControllerTest : BaseVardefTest() {
             .then()
             .statusCode(400)
             .body("_embedded.errors[0].message", containsString("id: must match \"^[a-zA-Z0-9-_]{8}$\""))
-        Assertions.assertThat(variableDefinitionService.listAll()).contains(SAVED_VARIABLE_DEFINITION)
     }
 
     @Test
@@ -81,7 +82,6 @@ class VariableDefinitionByIdControllerTest : BaseVardefTest() {
             .then()
             .statusCode(404)
             .body("_embedded.errors[0].message", containsString("No such variable definition found"))
-        Assertions.assertThat(variableDefinitionService.listAll()).contains(SAVED_VARIABLE_DEFINITION)
     }
 
     @Test
@@ -112,12 +112,23 @@ class VariableDefinitionByIdControllerTest : BaseVardefTest() {
                 .extract().body().asString()
         val body = jsonMapper.readValue(bodyString, InputVariableDefinition::class.java)
 
-        Assertions.assertThat(body.id).isEqualTo(SAVED_VARIABLE_DEFINITION.definitionId)
-        Assertions.assertThat(body.name).isEqualTo(expectedVariableDefinition.name)
-        Assertions.assertThat(body.definition).isEqualTo(SAVED_VARIABLE_DEFINITION.definition)
-        Assertions.assertThat(
-            variableDefinitionService.getOneById(expectedVariableDefinition.definitionId),
-        ).isEqualTo(expectedVariableDefinition)
+        assertThat(body.id).isEqualTo(SAVED_VARIABLE_DEFINITION.definitionId)
+        assertThat(body.name).isEqualTo(expectedVariableDefinition.name)
+        assertThat(body.definition).isEqualTo(SAVED_VARIABLE_DEFINITION.definition)
+
+        val updatedVariableDefinition = variableDefinitionService.getOneById(expectedVariableDefinition.definitionId)
+        assertThat(
+            updatedVariableDefinition.definitionId,
+        ).isEqualTo(expectedVariableDefinition.definitionId)
+        assertThat(
+            updatedVariableDefinition.createdAt,
+        ).isCloseTo(expectedVariableDefinition.createdAt, within(1, ChronoUnit.SECONDS))
+        assertThat(
+            updatedVariableDefinition.name,
+        ).isEqualTo(expectedVariableDefinition.name)
+        assertThat(
+            updatedVariableDefinition.lastUpdatedAt,
+        ).isAfter(expectedVariableDefinition.lastUpdatedAt)
     }
 
     @ParameterizedTest
@@ -198,10 +209,11 @@ class VariableDefinitionByIdControllerTest : BaseVardefTest() {
                 """.trimIndent(),
             )
             .`when`()
-            .patch("/variable-definitions/MALFORMED_ID")
+            .patch("/variable-definitions/${SAVED_VARIABLE_DEFINITION.definitionId}")
             .then()
             .statusCode(400)
             .body("_embedded.errors[0].message", containsString("Unknown property [id] encountered during deserialization of type"))
-        Assertions.assertThat(variableDefinitionService.listAll()).contains(SAVED_VARIABLE_DEFINITION)
+        assertThat(variableDefinitionService.listAll().map { it.definitionId }).contains(SAVED_VARIABLE_DEFINITION.definitionId)
+        assertThat(variableDefinitionService.listAll().map { it.name }).contains(SAVED_VARIABLE_DEFINITION.name)
     }
 }

--- a/src/test/kotlin/no/ssb/metadata/VariableDefinitionServiceTest.kt
+++ b/src/test/kotlin/no/ssb/metadata/VariableDefinitionServiceTest.kt
@@ -14,7 +14,6 @@ import no.ssb.metadata.services.VariableDefinitionService
 import org.assertj.core.api.AssertionsForClassTypes.assertThat
 import org.bson.types.ObjectId
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -72,8 +71,8 @@ class VariableDefinitionServiceTest {
         val renderedVariableDefinition = RENDERED_VARIABLE_DEFINITION.copy(id = variableDefinition.definitionId)
 
         val result = variableDefinitionService.listAllAndRenderForLanguage(SupportedLanguages.NB)
-        assert(result.isNotEmpty())
-        assertEquals(listOf(renderedVariableDefinition), result)
+        assertThat(result.isNotEmpty())
+        assertThat(listOf(renderedVariableDefinition).map { it.id }).isEqualTo(result.map { it.id })
         assertThat(result[0].id).isEqualTo(renderedVariableDefinition.id)
         verify { variableDefinitionMockRepository.findAll() }
     }

--- a/src/test/kotlin/no/ssb/metadata/VariableDefinitionsControllerTest.kt
+++ b/src/test/kotlin/no/ssb/metadata/VariableDefinitionsControllerTest.kt
@@ -11,6 +11,8 @@ import no.ssb.metadata.constants.INPUT_VARIABLE_DEFINITION_EXAMPLE
 import no.ssb.metadata.models.SupportedLanguages
 import no.ssb.metadata.services.VariableDefinitionService
 import no.ssb.metadata.utils.BaseVardefTest
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.Matchers.*
 import org.json.JSONObject
@@ -20,6 +22,8 @@ import org.junit.jupiter.api.TestInstance
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import org.junit.jupiter.params.provider.MethodSource
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 
 @MicronautTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -46,17 +50,27 @@ class VariableDefinitionsControllerEmptyDatabaseTest {
 class VariableDefinitionsControllerTest : BaseVardefTest() {
     @Test
     fun `create variable definition`(spec: RequestSpecification) {
-        spec
-            .given()
-            .contentType(ContentType.JSON)
-            .body(JSON_TEST_INPUT)
-            .`when`()
-            .post("/variable-definitions")
-            .then()
-            .statusCode(201)
-            .body("short_name", equalTo("landbak"))
-            .body("name.nb", equalTo("Landbakgrunn"))
-            .body("id", matchesRegex("^[a-zA-Z0-9-_]{8}\$"))
+        val startTime = LocalDateTime.now()
+
+        val definitionId =
+            spec
+                .given()
+                .contentType(ContentType.JSON)
+                .body(JSON_TEST_INPUT)
+                .`when`()
+                .post("/variable-definitions")
+                .then()
+                .statusCode(201)
+                .body("short_name", equalTo("landbak"))
+                .body("name.nb", equalTo("Landbakgrunn"))
+                .body("id", matchesRegex("^[a-zA-Z0-9-_]{8}\$"))
+                .extract().body().path<String>("id")
+
+        val createdVariableDefinition = variableDefinitionService.getOneById(definitionId)
+
+        assertThat(createdVariableDefinition.shortName).isEqualTo("landbak")
+        assertThat(createdVariableDefinition.createdAt).isCloseTo(startTime, within(1, ChronoUnit.MINUTES))
+        assertThat(createdVariableDefinition.createdAt).isEqualTo(createdVariableDefinition.lastUpdatedAt)
     }
 
     @Test

--- a/src/test/kotlin/no/ssb/metadata/utils/TestData.kt
+++ b/src/test/kotlin/no/ssb/metadata/utils/TestData.kt
@@ -1,8 +1,10 @@
+
 import io.viascom.nanoid.NanoId
 import no.ssb.metadata.models.*
 import org.bson.types.ObjectId
 import java.net.URI
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 val INPUT_VARIABLE_DEFINITION =
     InputVariableDefinition(
@@ -56,9 +58,9 @@ val SAVED_VARIABLE_DEFINITION =
         relatedVariableDefinitionUris = listOf(),
         owner = Owner("", ""),
         contact = Contact(LanguageStringType("", "", ""), "me@example.com"),
-        createdAt = "2024-06-11T08:15:19.421Z",
+        createdAt = LocalDateTime.parse("2024-06-11T08:15:19"),
         createdBy = Person("", ""),
-        lastUpdatedAt = "2024-06-11T08:15:19.421Z",
+        lastUpdatedAt = LocalDateTime.parse("2024-06-11T08:15:19"),
         lastUpdatedBy = Person("", ""),
     )
 
@@ -88,9 +90,9 @@ val RENDERED_VARIABLE_DEFINITION =
         relatedVariableDefinitionUris = listOf(),
         owner = Owner("", ""),
         contact = RenderedContact("", "me@example.com"),
-        createdAt = "2024-06-11T08:15:19.421Z",
+        createdAt = LocalDateTime.parse("2024-06-11T08:15:19"),
         createdBy = Person("", ""),
-        lastUpdatedAt = "2024-06-11T08:15:19.421Z",
+        lastUpdatedAt = LocalDateTime.parse("2024-06-11T08:15:19"),
         lastUpdatedBy = Person("", ""),
     )
 


### PR DESCRIPTION
- `created_at` is populated when a variable definition is created
- `last_updated_at` is populated when a variable definition is modified
- We implement this with the Micronaut Data annotations `@DateCreated` and `@DateUpdated`