### PR TITLE
Disallow variable status being specified on creation

### DIFF
--- a/src/main/kotlin/no/ssb/metadata/constants/SchemaExamples.kt
+++ b/src/main/kotlin/no/ssb/metadata/constants/SchemaExamples.kt
@@ -18,7 +18,6 @@ const val INPUT_VARIABLE_DEFINITION_EXAMPLE = """
     "subject_fields": ["he04"],
     "contains_unit_identifying_information": false,
     "contains_sensitive_personal_information": true,
-    "variable_status": "PUBLISHED_EXTERNAL",
     "measurement_type": null,
     "valid_from": "2003-01-01",
     "valid_until": null,

--- a/src/main/kotlin/no/ssb/metadata/controllers/VariableDefinitionsController.kt
+++ b/src/main/kotlin/no/ssb/metadata/controllers/VariableDefinitionsController.kt
@@ -40,7 +40,9 @@ class VariableDefinitionsController {
     /**
      * Create a variable definition.
      *
-     * New variable definitions must have status DRAFT and include all required fields.
+     * New variable definitions are automatically assigned status DRAFT and must include all required fields.
+     *
+     * Attempts to specify id or variable_status in a request will receive 400 BAD REQUEST responses.
      */
     @Post()
     @Status(HttpStatus.CREATED)
@@ -50,6 +52,12 @@ class VariableDefinitionsController {
         @Body @Valid varDef: InputVariableDefinition,
     ): InputVariableDefinition {
         if (varDef.id != null) throw HttpStatusException(HttpStatus.BAD_REQUEST, "ID may not be specified on creation.")
+        if (varDef.variableStatus != null) {
+            throw HttpStatusException(
+                HttpStatus.BAD_REQUEST,
+                "Variable status may not be specified on creation.",
+            )
+        }
         return varDefService.save(varDef.toSavedVariableDefinition()).toInputVariableDefinition()
     }
 }

--- a/src/main/kotlin/no/ssb/metadata/models/InputVariableDefinition.kt
+++ b/src/main/kotlin/no/ssb/metadata/models/InputVariableDefinition.kt
@@ -24,7 +24,7 @@ import java.time.LocalDateTime
 data class InputVariableDefinition(
     @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     @Nullable
-    val id: String?,
+    var id: String?,
     @Schema(description = NAME_FIELD_DESCRIPTION)
     val name: LanguageStringType,
     @Schema(description = SHORT_NAME_FIELD_DESCRIPTION)
@@ -55,8 +55,8 @@ data class InputVariableDefinition(
     @Schema(description = CONTAINS_SENSITIVE_PERSONAL_INFORMATION_FIELD_DESCRIPTION)
     @NotNull
     val containsSensitivePersonalInformation: Boolean,
-    @Schema(description = VARIABLE_STATUS_FIELD_DESCRIPTION)
-    val variableStatus: VariableStatus,
+    @Schema(description = VARIABLE_STATUS_FIELD_DESCRIPTION, accessMode = Schema.AccessMode.READ_ONLY)
+    var variableStatus: VariableStatus?,
     @Schema(description = MEASURMENT_TYPE_FIELD_DESCRIPTION)
     @Nullable
     @KlassCode("303")
@@ -80,7 +80,7 @@ data class InputVariableDefinition(
 ) {
     fun toSavedVariableDefinition(): SavedVariableDefinition =
         SavedVariableDefinition(
-            definitionId = NanoId.generate(8),
+            definitionId = id ?: NanoId.generate(8),
             name = name,
             shortName = shortName,
             definition = definition,
@@ -90,7 +90,7 @@ data class InputVariableDefinition(
             subjectFields = subjectFields,
             containsUnitIdentifyingInformation = containsUnitIdentifyingInformation,
             containsSensitivePersonalInformation = containsSensitivePersonalInformation,
-            variableStatus = variableStatus,
+            variableStatus = variableStatus ?: VariableStatus.DRAFT,
             measurementType = measurementType,
             validFrom = validFrom,
             validUntil = validUntil,

--- a/src/test/kotlin/no/ssb/metadata/utils/TestData.kt
+++ b/src/test/kotlin/no/ssb/metadata/utils/TestData.kt
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 
 val INPUT_VARIABLE_DEFINITION =
     InputVariableDefinition(
-        id = null,
+        id = NanoId.generate(8),
         name = LanguageStringType(nb = "Landbakgrunn", nn = "Landbakgrunn", en = "Country Background"),
         shortName = "landbak",
         definition = LanguageStringType(nb = "For personer født", nn = null, en = "Country background is"),
@@ -50,7 +50,7 @@ val SAVED_VARIABLE_DEFINITION =
         subjectFields = listOf("he04"),
         containsUnitIdentifyingInformation = false,
         containsSensitivePersonalInformation = false,
-        variableStatus = VariableStatus.DRAFT,
+        variableStatus = VariableStatus.PUBLISHED_EXTERNAL,
         measurementType = "02.01",
         validFrom = LocalDate.of(2021, 1, 4),
         validUntil = LocalDate.of(2021, 1, 4),
@@ -120,7 +120,6 @@ val JSON_TEST_INPUT =
         ],
         "contains_unit_identifying_information": true,
         "contains_sensitive_personal_information": true,
-        "variable_status": "DRAFT",
         "measurement_type": "02.01",
         "valid_from": "2024-06-05",
         "valid_until": "2024-06-05",

--- a/src/test/kotlin/no/ssb/metadata/utils/TestUtils.kt
+++ b/src/test/kotlin/no/ssb/metadata/utils/TestUtils.kt
@@ -92,9 +92,6 @@ object TestUtils {
                     remove("subject_fields")
                 } to "varDef.subjectFields: must not be empty",
                 JSONObject(JSON_TEST_INPUT).apply {
-                    remove("variable_status")
-                } to "null annotate it with @Nullable",
-                JSONObject(JSON_TEST_INPUT).apply {
                     remove("valid_from")
                 } to "null annotate it with @Nullable",
                 JSONObject(JSON_TEST_INPUT).apply {
@@ -110,16 +107,16 @@ object TestUtils {
             listOf(
                 JSONObject(JSON_TEST_INPUT).apply {
                     put("variable_status", "DRAFT")
-                } to HttpStatus.CREATED.code,
+                } to HttpStatus.BAD_REQUEST.code,
                 JSONObject(JSON_TEST_INPUT).apply {
                     put("variable_status", "PUBLISHED_INTERNAL")
-                } to HttpStatus.CREATED.code,
+                } to HttpStatus.BAD_REQUEST.code,
                 JSONObject(JSON_TEST_INPUT).apply {
                     put("variable_status", "PUBLISHED_EXTERNAL")
-                } to HttpStatus.CREATED.code,
+                } to HttpStatus.BAD_REQUEST.code,
                 JSONObject(JSON_TEST_INPUT).apply {
                     put("variable_status", "DEPRECATED")
-                } to HttpStatus.CREATED.code,
+                } to HttpStatus.BAD_REQUEST.code,
                 JSONObject(JSON_TEST_INPUT).apply {
                     put("variable_status", "Not a status")
                 } to HttpStatus.BAD_REQUEST.code,


### PR DESCRIPTION
- New variable definitions are automatically assigned status DRAFT.
- Attempts to specify id or variable_status in a request will receive 400 BAD REQUEST responses.