### PR TITLE
Remove contains_unit_identifying_information

### DIFF
--- a/openapi/schemas/input-variable-definition.yaml
+++ b/openapi/schemas/input-variable-definition.yaml
@@ -49,10 +49,6 @@ properties:
     examples:
       - ["he04"]
       - ["if02", "vf05"]
-  contains_unit_identifying_information:
-    title: Contains unit identifying information
-    description: True if variable instances contain information which can identify a Person, Family or Household. Applies even if the information is pseudonymized.
-    type: boolean
   contains_sensitive_personal_information:
     title: Contains unit identifying information
     description: |

--- a/src/main/kotlin/no/ssb/metadata/constants/SchemaDefinitions.kt
+++ b/src/main/kotlin/no/ssb/metadata/constants/SchemaDefinitions.kt
@@ -13,9 +13,6 @@ const val UNIT_TYPES_FIELD_DESCRIPTION =
 const val SUBJECT_FIELDS_FIELD_DESCRIPTION =
     "A list of subject fields that the variable is used in. " +
         "Must be defined as codes from https://www.ssb.no/klass/klassifikasjoner/618."
-const val CONTAINS_UNIT_IDENTIFYING_INFORMATION_FIELD_DESCRIPTION =
-    "True if variable instances contain information " +
-        "which can identify a Person, Family or Household. Applies even if the information is pseudonymized."
 const val CONTAINS_SENSITIVE_PERSONAL_INFORMATION_FIELD_DESCRIPTION =
     "True if variable instances contain particularly " +
         "sensitive information. Applies even if the information or identifiers are pseudonymized. " +

--- a/src/main/kotlin/no/ssb/metadata/constants/SchemaExamples.kt
+++ b/src/main/kotlin/no/ssb/metadata/constants/SchemaExamples.kt
@@ -16,7 +16,6 @@ const val INPUT_VARIABLE_DEFINITION_EXAMPLE = """
     "classification_reference": "91",
     "unit_types": ["01", "02"],
     "subject_fields": ["he04"],
-    "contains_unit_identifying_information": false,
     "contains_sensitive_personal_information": true,
     "measurement_type": null,
     "valid_from": "2003-01-01",
@@ -54,7 +53,6 @@ const val RENDERED_VARIABLE_DEFINITION_EXAMPLE = """{
             "title": "Innvandrere"
         }
     ],
-    "contains_unit_identifying_information": false,
     "contains_sensitive_personal_information": true,
     "variable_status": "PUBLISHED_EXTERNAL",
     "measurement_type": null,

--- a/src/main/kotlin/no/ssb/metadata/models/InputVariableDefinition.kt
+++ b/src/main/kotlin/no/ssb/metadata/models/InputVariableDefinition.kt
@@ -49,9 +49,6 @@ data class InputVariableDefinition(
         @KlassCode("618")
         String,
     >,
-    @Schema(description = CONTAINS_UNIT_IDENTIFYING_INFORMATION_FIELD_DESCRIPTION)
-    @NotNull
-    val containsUnitIdentifyingInformation: Boolean,
     @Schema(description = CONTAINS_SENSITIVE_PERSONAL_INFORMATION_FIELD_DESCRIPTION)
     @NotNull
     val containsSensitivePersonalInformation: Boolean,
@@ -88,7 +85,6 @@ data class InputVariableDefinition(
             classificationUri = "",
             unitTypes = unitTypes,
             subjectFields = subjectFields,
-            containsUnitIdentifyingInformation = containsUnitIdentifyingInformation,
             containsSensitivePersonalInformation = containsSensitivePersonalInformation,
             variableStatus = variableStatus ?: VariableStatus.DRAFT,
             measurementType = measurementType,

--- a/src/main/kotlin/no/ssb/metadata/models/RenderedVariableDefinition.kt
+++ b/src/main/kotlin/no/ssb/metadata/models/RenderedVariableDefinition.kt
@@ -20,7 +20,6 @@ data class RenderedVariableDefinition(
     val classificationUri: String?,
     val unitTypes: List<KlassReference>,
     val subjectFields: List<KlassReference>,
-    val containsUnitIdentifyingInformation: Boolean,
     val containsSensitivePersonalInformation: Boolean,
     val variableStatus: VariableStatus,
     val measurementType: KlassReference?,

--- a/src/main/kotlin/no/ssb/metadata/models/SavedVariableDefinition.kt
+++ b/src/main/kotlin/no/ssb/metadata/models/SavedVariableDefinition.kt
@@ -21,7 +21,6 @@ data class SavedVariableDefinition(
     var classificationUri: String?,
     var unitTypes: List<String>,
     var subjectFields: List<String>,
-    var containsUnitIdentifyingInformation: Boolean,
     var containsSensitivePersonalInformation: Boolean,
     var variableStatus: VariableStatus,
     @Nullable
@@ -56,7 +55,6 @@ data class SavedVariableDefinition(
             unitTypes = emptyList(),
             // TODO DPMETA-258
             subjectFields = emptyList(),
-            containsUnitIdentifyingInformation = containsUnitIdentifyingInformation,
             containsSensitivePersonalInformation = containsSensitivePersonalInformation,
             variableStatus = variableStatus,
             // TODO DPMETA-258
@@ -83,7 +81,6 @@ data class SavedVariableDefinition(
             classificationReference = "",
             unitTypes = unitTypes,
             subjectFields = subjectFields,
-            containsUnitIdentifyingInformation = containsUnitIdentifyingInformation,
             containsSensitivePersonalInformation = containsSensitivePersonalInformation,
             variableStatus = variableStatus,
             measurementType = measurementType,
@@ -114,9 +111,6 @@ data class SavedVariableDefinition(
             classificationUri = varDefUpdates.classificationReference ?: classificationUri,
             unitTypes = varDefUpdates.unitTypes ?: unitTypes,
             subjectFields = varDefUpdates.subjectFields ?: subjectFields,
-            containsUnitIdentifyingInformation =
-                varDefUpdates.containsUnitIdentifyingInformation
-                    ?: containsUnitIdentifyingInformation,
             containsSensitivePersonalInformation =
                 varDefUpdates.containsSensitivePersonalInformation
                     ?: containsSensitivePersonalInformation,

--- a/src/main/kotlin/no/ssb/metadata/models/UpdateVariableDefinition.kt
+++ b/src/main/kotlin/no/ssb/metadata/models/UpdateVariableDefinition.kt
@@ -49,9 +49,6 @@ data class UpdateVariableDefinition(
         @KlassCode("618")
         String,
     >?,
-    @Schema(description = CONTAINS_UNIT_IDENTIFYING_INFORMATION_FIELD_DESCRIPTION)
-    @Nullable
-    val containsUnitIdentifyingInformation: Boolean?,
     @Schema(description = CONTAINS_SENSITIVE_PERSONAL_INFORMATION_FIELD_DESCRIPTION)
     @Nullable
     val containsSensitivePersonalInformation: Boolean?,

--- a/src/test/kotlin/no/ssb/metadata/utils/TestData.kt
+++ b/src/test/kotlin/no/ssb/metadata/utils/TestData.kt
@@ -15,7 +15,6 @@ val INPUT_VARIABLE_DEFINITION =
         classificationReference = "91",
         unitTypes = listOf("", ""),
         subjectFields = listOf("", ""),
-        containsUnitIdentifyingInformation = false,
         containsSensitivePersonalInformation = false,
         variableStatus = VariableStatus.DRAFT,
         measurementType = "",
@@ -48,7 +47,6 @@ val SAVED_VARIABLE_DEFINITION =
         classificationUri = "https://www.ssb.no/en/klass/klassifikasjoner/91",
         unitTypes = listOf("01", "02"),
         subjectFields = listOf("he04"),
-        containsUnitIdentifyingInformation = false,
         containsSensitivePersonalInformation = false,
         variableStatus = VariableStatus.PUBLISHED_EXTERNAL,
         measurementType = "02.01",
@@ -80,7 +78,6 @@ val RENDERED_VARIABLE_DEFINITION =
         classificationUri = "https://www.ssb.no/en/klass/klassifikasjoner/91",
         unitTypes = emptyList(),
         subjectFields = emptyList(),
-        containsUnitIdentifyingInformation = false,
         containsSensitivePersonalInformation = false,
         variableStatus = VariableStatus.DRAFT,
         measurementType = null,
@@ -118,7 +115,6 @@ val JSON_TEST_INPUT =
         "subject_fields": [
             "he04"
         ],
-        "contains_unit_identifying_information": true,
         "contains_sensitive_personal_information": true,
         "measurement_type": "02.01",
         "valid_from": "2024-06-05",


### PR DESCRIPTION
The field contains_unit_identifying_information has been removed from the specifications, and should therefore be removed from VarDef.