### PR TITLE
Tag publicly available operations with 'Public'

### DIFF
--- a/.idea/runConfigurations/vardef_local__run_.xml
+++ b/.idea/runConfigurations/vardef_local__run_.xml
@@ -15,7 +15,6 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="clean" />
           <option value="run" />
         </list>
       </option>

--- a/src/main/kotlin/no/ssb/metadata/vardef/Application.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/Application.kt
@@ -33,8 +33,8 @@ import no.ssb.metadata.vardef.constants.*
     security = [SecurityRequirement(name = "Keycloak token")],
     tags = [
         Tag(
-            name = VARIABLE_DEFINITIONS,
-            description = "Access variable definitions.",
+            name = PUBLIC,
+            description = "Operations which are available to the general public without authentication.",
         ),
         Tag(
             name = VALIDITY_PERIODS,

--- a/src/main/kotlin/no/ssb/metadata/vardef/constants/OpenApiTags.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/constants/OpenApiTags.kt
@@ -3,5 +3,5 @@ package no.ssb.metadata.vardef.constants
 const val PATCHES = "Patches"
 const val VALIDITY_PERIODS = "Validity Periods"
 const val DATA_MIGRATION = "Data Migration"
-const val VARIABLE_DEFINITIONS = "Variable Definitions"
 const val DRAFT = "Draft Variable Definitions"
+const val PUBLIC = "Public"

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/VariableDefinitionByIdController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/VariableDefinitionByIdController.kt
@@ -33,7 +33,7 @@ class VariableDefinitionByIdController {
      *
      * This is rendered in the given language, with the default being Norwegian Bokmål.
      */
-    @Tag(name = VARIABLE_DEFINITIONS)
+    @Tag(name = PUBLIC)
     @Produces(MediaType.APPLICATION_JSON)
     @ApiResponse(
         responseCode = "200",

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/VariableDefinitionsController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/VariableDefinitionsController.kt
@@ -50,7 +50,7 @@ class VariableDefinitionsController {
             ),
         ],
     )
-    @Tag(name = VARIABLE_DEFINITIONS)
+    @Tag(name = PUBLIC)
     @Get()
     fun listVariableDefinitions(
         @Parameter(description = ACCEPT_LANGUAGE_HEADER_PARAMETER_DESCRIPTION, example = DEFAULT_LANGUAGE)


### PR DESCRIPTION
## Summary

Make clear which operations will be exposed to external consumers. This may be used for communication during development and for filtering displayed API documentation when we come to that.

## Screenshot

![Screenshot 2024-10-01 at 15 51 58](https://github.com/user-attachments/assets/707abe0b-1c26-4e68-83cb-f615e8c20df8)
