### PR TITLE
Vardok migration: Directly return client response

### DIFF
--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/VarDokMigrationController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/VarDokMigrationController.kt
@@ -73,7 +73,7 @@ class VarDokMigrationController {
             return httpClient.exchange(
                 HttpRequest.POST("/variable-definitions", varDefInput),
                 Argument.of(Draft::class.java),
-                DEFAULT_ERROR_TYPE
+                DEFAULT_ERROR_TYPE,
             )
         } catch (e: VardokNotFoundException) {
             throw HttpStatusException(HttpStatus.NOT_FOUND, e.message)


### PR DESCRIPTION
This will communicate detailed error messages from the service being called.

Ref: DPMETA-496