### PR TITLE
Allow access to /health endpoint

### DIFF
--- a/.nais/test.yaml
+++ b/.nais/test.yaml
@@ -40,12 +40,17 @@ spec:
   envFrom:
     - secret: metadata-vardef-test
 
+  prometheus:
+    enabled: true
+    path: /metrics
+    port: "8090"
+
   liveness:
     path: /health
-    port: 8080
+    port: 8090
   readiness:
     path: /health
-    port: 8080
+    port: 8090
   startup:
     path: /health
-    port: 8080
+    port: 8090

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,11 +13,17 @@ micronaut:
           values:
             dapla-lab-audience: onyxia-api
     intercept-url-map:
-      - pattern: /**
-        access: isAuthenticated()
+      - pattern: /health/**
+        http-method: GET
+        access: isAnonymous()
+      - pattern: /metrics/**
+        http-method: GET
+        access: isAnonymous()
       - pattern: /docs/**
         http-method: GET
         access: isAnonymous()
+      - pattern: /**
+        access: isAuthenticated()
   router:
     static-resources:
       swagger:
@@ -75,6 +81,15 @@ micronaut:
     url:
       en: https://www.ssb.no/en/klass
       nb: https://www.ssb.no/klass
+
+# Allow unauthenticated access
+endpoints:
+  all:
+    port: 8090
+  health:
+    sensitive: false
+  metrics:
+    sensitive: false
 
 klass:
   codes-at: 2024-08-01

--- a/src/test/kotlin/no/ssb/metadata/vardef/controllers/ManagementEndpointsTest.kt
+++ b/src/test/kotlin/no/ssb/metadata/vardef/controllers/ManagementEndpointsTest.kt
@@ -1,14 +1,23 @@
 package no.ssb.metadata.vardef.controllers
 
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import io.restassured.http.ContentType
 import io.restassured.specification.RequestSpecification
-import no.ssb.metadata.vardef.utils.BaseVardefTest
 import org.junit.jupiter.api.Test
 
-class ManagementEndpointsTest : BaseVardefTest() {
+@MicronautTest
+class ManagementEndpointsTest {
+    @Property(name = "endpoints.all.port")
+    private var endpointsPort: Int = 0
+
     @Test
     fun `health endpoint`(spec: RequestSpecification) {
         spec
+            .given()
+            .port(endpointsPort)
+            .auth()
+            .none()
             .`when`()
             .contentType(ContentType.JSON)
             .get("/health")
@@ -19,6 +28,10 @@ class ManagementEndpointsTest : BaseVardefTest() {
     @Test
     fun `metrics endpoint`(spec: RequestSpecification) {
         spec
+            .given()
+            .port(endpointsPort)
+            .auth()
+            .none()
             .`when`()
             .contentType(ContentType.JSON)
             .get("/metrics")
@@ -29,6 +42,9 @@ class ManagementEndpointsTest : BaseVardefTest() {
     @Test
     fun `swagger docs`(spec: RequestSpecification) {
         spec
+            .given()
+            .auth()
+            .none()
             .`when`()
             .contentType(ContentType.JSON)
             .get("/docs/swagger")
@@ -39,6 +55,9 @@ class ManagementEndpointsTest : BaseVardefTest() {
     @Test
     fun `redoc docs`(spec: RequestSpecification) {
         spec
+            .given()
+            .auth()
+            .none()
             .`when`()
             .contentType(ContentType.JSON)
             .get("/docs/redoc")


### PR DESCRIPTION
- Move managements endpoint to 8090 to prevent unintended access
- The general intercept-url-map is moved to the bottom so other rules take precedence
- Enable metrics scraping
- Fix tests
