### PR TITLE
Run Klass validation on blocking thread

### DIFF
--- a/src/main/kotlin/no/ssb/metadata/vardef/integrations/klass/validators/KlassValidationFactory.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/integrations/klass/validators/KlassValidationFactory.kt
@@ -1,12 +1,15 @@
 package no.ssb.metadata.vardef.integrations.klass.validators
 
 import io.micronaut.context.annotation.Factory
+import io.micronaut.scheduling.TaskExecutors
+import io.micronaut.scheduling.annotation.ExecuteOn
 import io.micronaut.validation.validator.constraints.ConstraintValidator
 import jakarta.inject.Singleton
 import no.ssb.metadata.vardef.integrations.klass.service.KlassService
 import kotlin.jvm.optionals.getOrElse
 
 @Factory
+@ExecuteOn(TaskExecutors.BLOCKING)
 class KlassValidationFactory(
     private val klassService: KlassService,
 ) {


### PR DESCRIPTION
Detected in logs:

```
2024-11-08 13:53:14 INFO 9d9ff96d8-n9wwc

[36m12:53:14.959[0;39m [1;30m[default-nioEventLoopGroup-1-8][0;39m [1;31mERROR[0;39m [35mi.m.http.server.RouteExecutor[0;39m - Unexpected error occurred: Cannot call 'isValid' on: no.ssb.metadata.vardef.integrations.klass.validators.KlassValidationFactory$$Lambda/0x00007cb7c6a37818

2024-11-08 13:53:14 INFO 9d9ff96d8-n9wwc

jakarta.validation.ValidationException: Cannot call 'isValid' on: no.ssb.metadata.vardef.integrations.klass.validators.KlassValidationFactory$$Lambda/0x00007cb7c6a37818
...
2024-11-08 13:53:14 INFO 9d9ff96d8-n9wwc

Caused by: io.micronaut.http.client.exceptions.HttpClientException: You are trying to run a BlockingHttpClient operation on a netty event loop thread. This is a common cause for bugs: Event loops should never be blocked. You can either mark your controller as @ExecuteOn(TaskExecutors.BLOCKING), or use the reactive HTTP client to resolve this bug. There is also a configuration option to disable this check if you are certain a blocking operation is fine here.
```