### PR TITLE
Reverting debug logs on security rule

### DIFF
--- a/src/main/resources/logback-kubernetes.xml
+++ b/src/main/resources/logback-kubernetes.xml
@@ -13,8 +13,6 @@
         </encoder>
     </appender>
 
-    <logger name="io.micronaut.security.rules.AbstractSecurityRule" level="debug" />
-
     <root level="info">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
Reverted setting security rule logs to debug, as it creates to many logs