### PR TITLE
Unchanged draft short name should not result in conflict

### DIFF
--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/VariableDefinitionByIdController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/VariableDefinitionByIdController.kt
@@ -203,7 +203,10 @@ class VariableDefinitionByIdController(
                 "The variable is published or deprecated and cannot be updated with this method",
             )
 
-            vardef.isShortNameConflict(updateDraft.shortName, variable.shortName) ->
+            (
+                updateDraft.shortName != null && updateDraft.shortName != variable.shortName &&
+                    vardef.doesShortNameExist(updateDraft.shortName)
+            ) ->
                 throw HttpStatusException(
                     HttpStatus.CONFLICT,
                     "The short name '${updateDraft.shortName}' is already in use by another variable definition.",

--- a/src/main/kotlin/no/ssb/metadata/vardef/services/VariableDefinitionService.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/services/VariableDefinitionService.kt
@@ -98,20 +98,6 @@ class VariableDefinitionService(
     }
 
     /**
-     * When updating Draft there is only shortName conflict if the shortName is changed
-     *
-     * @param newShortName shortName from input
-     * @param existingShortName shortName saved Draft
-     * @return 'true' if the [newShortName] is changed and already exists
-     */
-    fun isShortNameConflict(
-        newShortName: String?,
-        existingShortName: String,
-    ): Boolean {
-        return (newShortName != null && newShortName != existingShortName && doesShortNameExist(newShortName))
-    }
-
-    /**
      * @return `true` if [group] is an owner of the *Variable Definition*
      */
     fun groupIsOwner(


### PR DESCRIPTION
There is a possibility that users will submit also unchanged fields when updating a Draft. 
A check on changed shortName will prevent a shortName conflict when the shortName is not changed.

### Suggestion:
- Add check on changed short name when updating Draft

