### PR TITLE
Remove vardok health check

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,9 +90,6 @@ micronaut:
         health-check-interval: 15s
       vardok:
         url: https://www.ssb.no/a/xml/metadata/conceptvariable/vardok
-        health-check: true
-        health-check-interval: 15s
-        health-check-uri: /1919/nb
       dapla-team-api:
         url: https://dapla-team-api.intern.test.ssb.no
         health-check: true


### PR DESCRIPTION
If this fails it will cause Kubernetes to try to
restart vardef continuously. We don't want this
because vardef provides value even without vardok.
