### PR TITLE
re-add removed backslash causing bug in vardok request

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -98,7 +98,7 @@ micronaut:
         health-check: true
         health-check-interval: 15s
       vardok:
-        url: https://www.ssb.no/a/xml/metadata/conceptvariable/vardok
+        url: https://www.ssb.no/a/xml/metadata/conceptvariable/vardok/
       dapla-team-api:
         url: https://dapla-team-api.intern.test.ssb.no
         health-check: true


### PR DESCRIPTION
It seems like backslash was removed from url to Vardok xml documents. This caused error in url when fetching Vardok element, for example trying to fetch from "https://www.ssb.no/a/xml/metadata/conceptvariable/vardok90". 

![Screenshot 2025-01-02 at 11 24 16](https://github.com/user-attachments/assets/33e48c95-e371-4eaf-8bee-e90e652d4ef5)
