### PR TITLE
chore/update schema examples

### DIFF
--- a/src/main/kotlin/no/ssb/metadata/vardef/constants/SchemaExamples.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/constants/SchemaExamples.kt
@@ -67,6 +67,41 @@ const val DRAFT_EXAMPLE = """{
     }
 }"""
 
+const val DRAFT_UPDATE_EXAMPLE = """{
+    "name": {
+        "en": "The Country Background",
+        "nb": "Landbakgrunnen",
+        "nn": "Landbakgrunnen"
+    },
+    "short_name": "landbak",
+    "definition": {
+        "en": "Country background is the person's own, the mother's or possibly the father's country of birth. Persons without an immigrant background always have Norway as country background. In cases where the parents have different countries of birth the mother's country of birth is chosen. If neither the person nor the parents are born abroad, country background is chosen from the first person born abroad in the order mother's mother, mother's father, father's mother, father's father.",
+        "nb": "For personer født i utlandet, er dette (med noen få unntak) eget fødeland. For personer født i Norge er det foreldrenes fødeland. I de tilfeller der foreldrene har ulikt fødeland, er det morens fødeland som blir valgt. Hvis ikke personen selv eller noen av foreldrene er utenlandsfødt, hentes landbakgrunn fra de første utenlandsfødte en treffer på i rekkefølgen mormor, morfar, farmor eller farfar.",
+        "nn": "For personar fødd i utlandet, er dette (med nokre få unntak) eige fødeland. For personar fødd i Noreg er det fødelandet til foreldra. I dei tilfella der foreldra har ulikt fødeland, er det fødelandet til mora som blir valt. Viss ikkje personen sjølv eller nokon av foreldra er utenlandsfødt, blir henta landsbakgrunn frå dei første utenlandsfødte ein treffar på i rekkjefølgja mormor, morfar, farmor eller farfar."
+    },
+    "classification_reference": "91",
+    "unit_types": ["01", "02"],
+    "subject_fields": ["he04"],
+    "valid_from": "2003-01-01",
+    "external_reference_uri": "https://www.ssb.no/a/metadata/conceptvariable/vardok/1919/nb",
+    "comment": {
+        "nb": "Rette skrivefeil",
+        "nn": "korrigere skrivefeil",
+        "en": "Correct spellling."
+    },
+    "related_variable_definition_uris": [
+        "https://example.com/"
+    ],
+    "contact": {
+        "title": {
+            "en": "Division for population statistics",
+            "nb": "Seksjon for befolkningsstatistikk",
+            "nn": "Seksjon for befolkningsstatistikk"
+        },
+        "email": "s320@ssb.no"
+    }
+}"""
+
 const val UPDATE_DRAFT_EXAMPLE = """{"classification_reference": "702"}"""
 
 const val UPDATE_DRAFT_CONSTRAINT_VIOLATION_EXAMPLE = """{"classification_reference": "incorrect"}"""

--- a/src/test/kotlin/no/ssb/metadata/vardef/constants/SchemaExamplesTest.kt
+++ b/src/test/kotlin/no/ssb/metadata/vardef/constants/SchemaExamplesTest.kt
@@ -32,7 +32,7 @@ class SchemaExamplesTest {
                 ),
                 argumentSet(
                     "Draft example validates",
-                    DRAFT_EXAMPLE,
+                    DRAFT_UPDATE_EXAMPLE,
                     listOf(Draft::class.java, UpdateDraft::class.java),
                 ),
                 argumentSet(


### PR DESCRIPTION
Make sure open-api examples are updated according to new code and generated code in Vardef client
Draft and UpdateDraft are now slightly different since it is not possible to update valid until
- **add valid until for draft**
- **update schema examples since valid until now is a field in draft but not in update draft**
