### PR TITLE
add tags application

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -128,6 +128,8 @@ endpoints:
   metrics:
     sensitive: false
     enabled: true
+    tags:
+      application: vardef
     export:
       prometheus:
         enabled: true


### PR DESCRIPTION
Not sure if this is correct for Micronaut, but according to the [JVM Micrometer dashboard](https://grafana.com/grafana/dashboards/4701-jvm-micrometer/) common tag `application` is used.

In the created Dashboard the only `Application` available in test is 
[Dapla team Api v2](https://github.com/statisticsnorway/dapla-team-api/blob/388b2a3bf0010baa22be8117e13e807ffc965975/src/main/resources/config/application.yaml#L50)
