### PR TITLE
Fix errors alert

### DIFF
--- a/.nais/test/alerts.yaml
+++ b/.nais/test/alerts.yaml
@@ -20,17 +20,20 @@ spec:
             service: vardef
             namespace: dapla-metadata
             severity: critical
+            environment: test
 
         - alert: A Vardef client is unavailable
-          expr: rate(http_client_requests_seconds_count{app="vardef", status!="200"}[15s]) > 0
+          expr: rate(http_client_requests_seconds_count{app="vardef", status!="200"}[1m]) > 0
           for: 1m
           annotations:
             title: "A Vardef client is unavailable "
             consequence: "The service may lack some functionality"
+            description: "Client {{ $labels.serviceId }} responded with {{ $labels.status }} causing {{ $labels.exception }}"
           labels:
             service: vardef
             namespace: dapla-metadata
             severity: critical
+            environment: test
 
         - alert: Vardef is unavailable
           expr: kube_deployment_status_replicas_available{deployment="vardef"} == 0
@@ -42,3 +45,4 @@ spec:
             service: vardef
             namespace: dapla-metadata
             severity: critical
+            environment: test


### PR DESCRIPTION
- **High number of errors uses correct metric**
- **Extend the rate window to ensure we capture client downtime**

It looks like our application doesn't publish `log_messages_total` metrics, so I changed it to the `logback_events_total` which has the same effect. See the graph below with the errors from this morning clearly visible.

![Screenshot 2025-02-05 at 13 39 13](https://github.com/user-attachments/assets/5c49ae48-5151-4213-8b96-f3f08b3c5bdd)

Also experiment with enriching the alert messages with information from Prometheus.