### PR TITLE
Check for translations in all languages for all relevant fields

### DIFF
--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/VariableDefinitionByIdController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/VariableDefinitionByIdController.kt
@@ -251,10 +251,10 @@ class VariableDefinitionByIdController(
                 HttpStatus.BAD_REQUEST,
                 "Invalid date order",
             )
-            !vardef.allLanguagesPresentForExternalPublication(updateDraft.variableStatus, updateDraft.definition, existingVariable) ->
+            !vardef.allLanguagesPresentForExternalPublication(updateDraft, existingVariable) ->
                 throw HttpStatusException(
                     HttpStatus.CONFLICT,
-                    "The variable must be defined in all languages before external publication.",
+                    "The variable must have translations for all languages for name, definition, comment before external publication.",
                 )
         }
         return vardef

--- a/src/test/kotlin/no/ssb/metadata/vardef/controllers/variabledefinitionbyid/UpdateTests.kt
+++ b/src/test/kotlin/no/ssb/metadata/vardef/controllers/variabledefinitionbyid/UpdateTests.kt
@@ -269,7 +269,7 @@ class UpdateTests : BaseVardefTest() {
             .statusCode(200)
             .body("comment.nb", containsString("Legger til merknad"))
             .body("comment.nn", containsString("Endrer merknad"))
-            .body("comment.en", nullValue())
+            .body("comment.en", containsString("Adding comment"))
     }
 
     @Test
@@ -366,7 +366,7 @@ class UpdateTests : BaseVardefTest() {
                 comment =
                     SAVED_DRAFT_DEADWEIGHT_EXAMPLE.comment?.copy(
                         nb = "Update",
-                        en = null,
+                        en = "Adding comment",
                         nn = "Updated comment",
                     ),
             )

--- a/src/test/kotlin/no/ssb/metadata/vardef/utils/TestData.kt
+++ b/src/test/kotlin/no/ssb/metadata/vardef/utils/TestData.kt
@@ -317,8 +317,8 @@ val SAVED_DRAFT_DEADWEIGHT_EXAMPLE =
         comment =
             LanguageStringType(
                 "Legger til merknad",
-                null,
-                null,
+                "Legger til merknad",
+                "Adding comment",
             ),
         relatedVariableDefinitionUris = listOf(),
         owner =


### PR DESCRIPTION
Expands the check to apply to name and comment in addition to definition.