### PR TITLE
Only include runtime dependencies in SBOM

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,7 @@ plugins {
     alias(libs.plugins.micronaut.aot)
     alias(libs.plugins.ktlint)
     alias(libs.plugins.jib)
-
-    id("org.cyclonedx.bom") version "2.1.0"
+    alias(libs.plugins.cyclonedx)
     id("jacoco")
 }
 
@@ -84,6 +83,11 @@ micronaut {
         optimizeNetty = true
         replaceLogbackXml = true
     }
+}
+
+tasks.cyclonedxBom {
+    setIncludeConfigs(listOf("runtimeClasspath"))
+    setProjectType("application")
 }
 
 jib {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@
 
 [versions]
 assertj = "3.27.3"
+cyclonedx = "2.1.0"
 jackson = "2.18.3"
 jib = "3.4.5"
 json = "20250107"
@@ -72,6 +73,7 @@ snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
 
 [plugins]
 allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
+cyclonedx = { id = "org.cyclonedx.bom", version.ref = "cyclonedx" }
 jib = { id = "com.google.cloud.tools.jib", version.ref = "jib" }
 jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }


### PR DESCRIPTION
The vulnerability report on nais was showing vulnerabilities introduced through ktlint-cli, which is not included in the built image. Reduce the scope of the SBOM to only include runtime dependencies.