### PR TITLE
Simplify null handling of LanguageStringType

### DIFF
--- a/src/main/kotlin/no/ssb/metadata/vardef/models/LanguageStringType.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/models/LanguageStringType.kt
@@ -67,10 +67,12 @@ data class LanguageStringType(
      * @param updates the updates
      * @return the merged object
      */
-    fun update(updates: LanguageStringType): LanguageStringType =
-        this.copy(
+    fun update(updates: LanguageStringType?): LanguageStringType {
+        if (updates == null) return this
+        return this.copy(
             nb = updates.nb ?: nb,
             nn = updates.nn ?: nn,
             en = updates.en ?: en,
         )
+    }
 }

--- a/src/main/kotlin/no/ssb/metadata/vardef/models/SavedVariableDefinition.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/models/SavedVariableDefinition.kt
@@ -144,9 +144,9 @@ data class SavedVariableDefinition(
         userName: String,
     ): SavedVariableDefinition =
         copy(
-            name = varDefUpdates.name?.let { name.update(it) } ?: name,
+            name = name.update(varDefUpdates.name),
             shortName = varDefUpdates.shortName ?: shortName,
-            definition = varDefUpdates.definition?.let { definition.update(it) } ?: definition,
+            definition = definition.update(varDefUpdates.definition),
             classificationReference = varDefUpdates.classificationReference ?: classificationReference,
             unitTypes = varDefUpdates.unitTypes ?: unitTypes,
             subjectFields = varDefUpdates.subjectFields ?: subjectFields,
@@ -157,7 +157,7 @@ data class SavedVariableDefinition(
             validFrom = varDefUpdates.validFrom ?: validFrom,
             validUntil = varDefUpdates.validUntil ?: validUntil,
             externalReferenceUri = varDefUpdates.externalReferenceUri ?: externalReferenceUri,
-            comment = varDefUpdates.comment?.let { comment?.update(it) } ?: comment,
+            comment = comment?.update(varDefUpdates.comment) ?: varDefUpdates.comment,
             relatedVariableDefinitionUris =
                 varDefUpdates.relatedVariableDefinitionUris?.map { it.toString() } ?: relatedVariableDefinitionUris,
             owner = varDefUpdates.owner ?: owner,

--- a/src/test/kotlin/no/ssb/metadata/vardef/controllers/variabledefinitionbyid/UpdateTests.kt
+++ b/src/test/kotlin/no/ssb/metadata/vardef/controllers/variabledefinitionbyid/UpdateTests.kt
@@ -250,7 +250,7 @@ class UpdateTests : BaseVardefTest() {
     }
 
     @Test
-    fun `update draft variable definition add comment`(spec: RequestSpecification) {
+    fun `update draft variable definition add new languages to comment`(spec: RequestSpecification) {
         spec
             .given()
             .contentType(ContentType.JSON)
@@ -270,6 +270,29 @@ class UpdateTests : BaseVardefTest() {
             .body("comment.nb", containsString("Legger til merknad"))
             .body("comment.nn", containsString("Endrer merknad"))
             .body("comment.en", containsString("Adding comment"))
+    }
+
+    @Test
+    fun `update draft variable definition add comment existing comment is null`(spec: RequestSpecification) {
+        spec
+            .given()
+            .contentType(ContentType.JSON)
+            .body(
+                """
+                {"comment": {
+                    "nb": "Legger til merknad",
+                    "nn": "Endrer merknad",
+                    "en": null
+                }}
+                """.trimIndent(),
+            ).queryParam(ACTIVE_GROUP, TEST_DEVELOPERS_GROUP)
+            .`when`()
+            .patch("/variable-definitions/${DRAFT_BUS_EXAMPLE.definitionId}")
+            .then()
+            .statusCode(200)
+            .body("comment.nb", containsString("Legger til merknad"))
+            .body("comment.nn", containsString("Endrer merknad"))
+            .body("comment.en", equalTo(null))
     }
 
     @Test


### PR DESCRIPTION
This fixes the case where it was not possible to update `comment` if its value was set to `null` and makes the code more readable.

Ref: DPMETA-852