### PR TITLE
Chore/update migration examples

### DIFF
--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VarDokMigrationController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VarDokMigrationController.kt
@@ -170,7 +170,7 @@ class VarDokMigrationController(
                 ),
             ],
     )
-    fun getCorrespodingVariableDefinitionById(
+    fun getVardokVardefMappingById(
         @Parameter(
             name = "id",
             description = "The ID of the definition in Vardok or Vardef.",


### PR DESCRIPTION
- Removed NotFoundApiResonse from get vardok-migration/{id} endpoint