### PR TITLE
Public api find by shortname

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,6 +44,14 @@ jobs:
           jacocoTestReport
           --daemon --parallel --build-cache
 
+      - name: SonarQube Cloud Scan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        # No need to run SonarCloud analysis if dependabot update or token not defined
+        if: env.SONAR_TOKEN != '' && (github.actor != 'dependabot[bot]')
+        uses: SonarSource/sonarqube-scan-action@v7.1.0
+
   check-format-and-code-quality:
     name: Check format and code quality
     runs-on: ubuntu-latest
@@ -67,11 +75,3 @@ jobs:
           ./gradlew
           ktlintCheck
           --daemon --parallel --build-cache
-
-      - name: SonarQube Cloud Scan
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        # No need to run SonarCloud analysis if dependabot update or token not defined
-        if: env.SONAR_TOKEN != '' && (github.actor != 'dependabot[bot]')
-        uses: SonarSource/sonarqube-scan-action@v7.1.0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,7 +4,7 @@ name: Run tests
 on:
   push:
     paths:
-      - src
+      - src/**
       - gradle/libs.versions.toml
       - build.gradle.kts
       - .github/workflows/run-tests.yml

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionsController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionsController.kt
@@ -128,7 +128,6 @@ class VariableDefinitionsController(
                 .contentType(MediaType.APPLICATION_JSON)
         }
 
-
     /**
      * Create a variable definition.
      *

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionsController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionsController.kt
@@ -128,6 +128,7 @@ class VariableDefinitionsController(
                 .contentType(MediaType.APPLICATION_JSON)
         }
 
+
     /**
      * Create a variable definition.
      *

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/publicapi/PublicController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/publicapi/PublicController.kt
@@ -74,9 +74,17 @@ class PublicController(
             ],
         )
         dateOfValidity: LocalDate? = null,
+        @QueryValue("short_name")
+        @Parameter(
+            description = SHORT_NAME_QUERY_PARAM_DESCRIPTION,
+            examples = [
+                ExampleObject(name = "Specific short_name", value = SHORT_NAME_EXAMPLE),
+            ],
+        )
+        shortName: String? = null,
     ): HttpResponse<List<RenderedView>> =
         HttpResponse
-            .ok(varDefService.listPublicForDate(language = language ?: SupportedLanguages.DEFAULT, dateOfValidity = dateOfValidity))
+            .ok(varDefService.listPublicForDate(language = language ?: SupportedLanguages.DEFAULT, dateOfValidity = dateOfValidity, shortName = shortName))
             .header(HttpHeaders.CONTENT_LANGUAGE, language.toString())
 
     /**

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/publicapi/PublicController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/publicapi/PublicController.kt
@@ -84,8 +84,13 @@ class PublicController(
         shortName: String? = null,
     ): HttpResponse<List<RenderedView>> =
         HttpResponse
-            .ok(varDefService.listPublicForDate(language = language ?: SupportedLanguages.DEFAULT, dateOfValidity = dateOfValidity, shortName = shortName))
-            .header(HttpHeaders.CONTENT_LANGUAGE, language.toString())
+            .ok(
+                varDefService.listPublicForDate(
+                    language = language ?: SupportedLanguages.DEFAULT,
+                    dateOfValidity = dateOfValidity,
+                    shortName = shortName,
+                ),
+            ).header(HttpHeaders.CONTENT_LANGUAGE, language.toString())
 
     /**
      * Get one variable definition.

--- a/src/main/kotlin/no/ssb/metadata/vardef/services/VariableDefinitionService.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/services/VariableDefinitionService.kt
@@ -147,16 +147,14 @@ class VariableDefinitionService(
     ): List<RenderedView> {
         val results =
             if (shortName != null) {
-                variableDefinitionRepository
-                    .findDistinctDefinitionIdByShortName(shortName)
-                    .let { id ->
-                        listOfNotNull(
-                            id?.let {
-                                getCompleteByDateAndStatus(it, dateOfValidity, VariableStatus.PUBLISHED_EXTERNAL)
-                                    ?.render(language, klassService)
-                            },
-                        )
-                    }
+                listOfNotNull(
+                    variableDefinitionRepository
+                        .findDistinctDefinitionIdByShortName(shortName)
+                        ?.let {
+                            getCompleteByDateAndStatus(it, dateOfValidity, VariableStatus.PUBLISHED_EXTERNAL)
+                                ?.render(language, klassService)
+                        }
+                )
             } else {
                 uniqueDefinitionIdsByStatus(VariableStatus.PUBLISHED_EXTERNAL)
                     .map {

--- a/src/main/kotlin/no/ssb/metadata/vardef/services/VariableDefinitionService.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/services/VariableDefinitionService.kt
@@ -156,7 +156,7 @@ class VariableDefinitionService(
                                 dateOfValidity,
                                 VariableStatus.PUBLISHED_EXTERNAL,
                             )?.render(language, klassService)
-                        }
+                        },
                 )
             } else {
                 uniqueDefinitionIdsByStatus(VariableStatus.PUBLISHED_EXTERNAL)

--- a/src/main/kotlin/no/ssb/metadata/vardef/services/VariableDefinitionService.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/services/VariableDefinitionService.kt
@@ -150,9 +150,12 @@ class VariableDefinitionService(
                 listOfNotNull(
                     variableDefinitionRepository
                         .findDistinctDefinitionIdByShortName(shortName)
-                        ?.let {
-                            getCompleteByDateAndStatus(it, dateOfValidity, VariableStatus.PUBLISHED_EXTERNAL)
-                                ?.render(language, klassService)
+                        ?.let { id ->
+                            getCompleteByDateAndStatus(
+                                id,
+                                dateOfValidity,
+                                VariableStatus.PUBLISHED_EXTERNAL,
+                            )?.render(language, klassService)
                         }
                 )
             } else {

--- a/src/main/kotlin/no/ssb/metadata/vardef/services/VariableDefinitionService.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/services/VariableDefinitionService.kt
@@ -137,23 +137,38 @@ class VariableDefinitionService(
      *
      * @param language The language to render in.
      * @param dateOfValidity The date which *Variable Definitions* shall be valid at.
+     * @param shortName The shortname which one wants a variable definition for.
      * @return [List<RenderedView>] with status [VariableStatus.PUBLISHED_EXTERNAL] valid at the date.
      */
     fun listPublicForDate(
         language: SupportedLanguages,
         dateOfValidity: LocalDate?,
+        shortName: String? = null,
     ): List<RenderedView> {
         val results =
-            uniqueDefinitionIdsByStatus(VariableStatus.PUBLISHED_EXTERNAL)
-                .map {
-                    getRenderedByDateAndStatus(
-                        language,
-                        it,
-                        dateOfValidity,
-                        VariableStatus.PUBLISHED_EXTERNAL,
-                    )
-                }
-        logger.info("Found ${results.size} valid public variable definitions at date $dateOfValidity.")
+            if (shortName != null) {
+                variableDefinitionRepository
+                    .findDistinctDefinitionIdByShortName(shortName)
+                    .let { id ->
+                        listOfNotNull(
+                            id?.let {
+                                getCompleteByDateAndStatus(it, dateOfValidity, VariableStatus.PUBLISHED_EXTERNAL)
+                                    ?.render(language, klassService)
+                            },
+                        )
+                    }
+            } else {
+                uniqueDefinitionIdsByStatus(VariableStatus.PUBLISHED_EXTERNAL)
+                    .map {
+                        getRenderedByDateAndStatus(
+                            language,
+                            it,
+                            dateOfValidity,
+                            VariableStatus.PUBLISHED_EXTERNAL,
+                        )
+                    }
+            }
+        logger.info("Found ${results.size} valid public variable definitions at date $dateOfValidity with shortName=$shortName.")
         return results
     }
 

--- a/src/test/kotlin/no/ssb/metadata/vardef/controllers/PublicControllerTest.kt
+++ b/src/test/kotlin/no/ssb/metadata/vardef/controllers/PublicControllerTest.kt
@@ -261,12 +261,90 @@ class PublicControllerTest : BaseVardefTest() {
             .body("[0].subject_fields[0].title", equalTo("Helsetjenester"))
     }
 
+    @Test
+    fun `list variable definitions by short name that does not exist`(spec: RequestSpecification) {
+        spec
+            .`when`()
+            .get("$publicVariableDefinitionsPath?short_name=nonexistent_shortname")
+            .then()
+            .statusCode(HttpStatus.OK.code)
+            .body("size()", equalTo(0))
+    }
+
+    @Test
+    fun `list variable definitions by short name of published external variable`(spec: RequestSpecification) {
+        spec
+            .`when`()
+            .get("$publicVariableDefinitionsPath?short_name=${INCOME_TAX_VP2_P6.shortName}")
+            .then()
+            .statusCode(HttpStatus.OK.code)
+            .body("size()", equalTo(1))
+            .body("[0].short_name", equalTo(INCOME_TAX_VP2_P6.shortName))
+    }
+
+    @Test
+    fun `list variable definitions by short name of draft variable returns empty list`(spec: RequestSpecification) {
+        spec
+            .`when`()
+            .get("$publicVariableDefinitionsPath?short_name=${DRAFT_BUS_EXAMPLE.shortName}")
+            .then()
+            .statusCode(HttpStatus.OK.code)
+            .body("size()", equalTo(0))
+    }
+
+    @Test
+    fun `list variable definitions by short name of published internal variable returns empty list`(spec: RequestSpecification) {
+        spec
+            .`when`()
+            .get("$publicVariableDefinitionsPath?short_name=${SAVED_INTERNAL_VARIABLE_DEFINITION.shortName}")
+            .then()
+            .statusCode(HttpStatus.OK.code)
+            .body("size()", equalTo(0))
+    }
+
+    @ParameterizedTest
+    @MethodSource("getByShortnames")
+    fun `list public variable definitions by short name with or without date`(
+        url: String,
+        expectedPatchId: Int,
+        spec: RequestSpecification,
+    ) {
+        val body =
+            spec
+                .`when`()
+                .get(url)
+                .then()
+                .statusCode(HttpStatus.OK.code)
+                .extract()
+                .body()
+                .asString()
+
+        val results = jsonMapper.readValue(body, Array<RenderedView>::class.java)
+        assertThat(results).hasSize(1)
+        assertThat(results[0].patchId).isEqualTo(expectedPatchId)
+    }
+
     companion object {
         @JvmStatic
         fun internalDefinitionIds(): Stream<Arguments> =
             Stream.of(
                 argumentSet("PUBLISHED_INTERNAL", SAVED_INTERNAL_VARIABLE_DEFINITION.definitionId),
                 argumentSet("DRAFT", DRAFT_BUS_EXAMPLE.definitionId),
+            )
+
+        @JvmStatic
+        fun getByShortnames(): Stream<Arguments> =
+            Stream.of(
+                argumentSet(
+                    "Short name and no date",
+                    "/public/variable-definitions?short_name=${INCOME_TAX_VP2_P6.shortName}",
+                    6,
+                ),
+                argumentSet(
+                    "Short name and date",
+                    "/public/variable-definitions?date_of_validity=1990-01-01&short_name=${INCOME_TAX_VP2_P6.shortName}",
+                    7,
+                ),
             )
     }
 }


### PR DESCRIPTION
- Add get by shortname in pulbic api, using similar setup as for the internal
- Added tests making sure we are only able to get external variables 
- Fixed sonar cloud integration