### PR TITLE
Update docs for external api

### DIFF
--- a/src/main/kotlin/no/ssb/metadata/vardef/Application.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/Application.kt
@@ -28,7 +28,25 @@ import reactor.core.publisher.Mono
             info =
                 Info(
                     title = "Public Variable Definitions API",
-                    description = """Public Variable Definitions""",
+                    description = """
+## Introduction
+Variable Definitions are centralized definitions of concrete variables which are typically present in multiple datasets. Variable Definitions support standardization of data and metadata and facilitate sharing and joining of data by clarifying when variables have an identical definition.
+
+## Read Access
+This API exposes Variable Definitions with status `PUBLISHED_EXTERNAL`. No authentication is required.
+
+### Language
+Responses are rendered in the language given by the `Accept-Language` header. Supported values are `nb` (Norwegian Bokmål), `nn` (Norwegian Nynorsk) and `en` (English). The default is `nb`.
+
+### Immutability
+Variable Definitions are immutable. This means that any changes must be performed in a strict versioning system. Consumers can avoid being exposed to breaking changes by specifying a `date_of_validity` when they request a Variable Definition.
+
+#### Patches
+Patches are for changes which do not affect the fundamental meaning of the Variable Definition.
+
+#### Validity Periods
+Validity Periods are versions with a period defined by a `valid_from` date and optionally a `valid_until` date. A new Validity Period indicates that the fundamental meaning of the Variable Definition has changed from that date onwards.
+""",
                     version = "0.1",
                     license = License(name = "CC BY 4.0", url = "https://creativecommons.org/licenses/by/4.0/deed.no"),
                     contact = Contact(email = "metadata@ssb.no", name = "Team Metadata"),

--- a/src/main/kotlin/no/ssb/metadata/vardef/Application.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/Application.kt
@@ -41,9 +41,6 @@ Responses are rendered in the language given by the `Accept-Language` header. Su
 ### Immutability
 Variable Definitions are immutable. This means that any changes must be performed in a strict versioning system. Consumers can avoid being exposed to breaking changes by specifying a `date_of_validity` when they request a Variable Definition.
 
-#### Patches
-Patches are for changes which do not affect the fundamental meaning of the Variable Definition.
-
 #### Validity Periods
 Validity Periods are versions with a period defined by a `valid_from` date and optionally a `valid_until` date. A new Validity Period indicates that the fundamental meaning of the Variable Definition has changed from that date onwards.
 """,

--- a/src/main/kotlin/no/ssb/metadata/vardef/constants/SchemaExamples.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/constants/SchemaExamples.kt
@@ -246,8 +246,9 @@ const val CREATE_VALIDITY_PERIOD_EXAMPLE = """
 """
 const val RENDERED_VIEW_EXAMPLE = """{
     "id": "$ID_EXAMPLE",
+    "patch_id": 1,
     "name": "Landbakgrunn",
-    "short_name": "string",
+    "short_name": "landbak",
     "definition": "For personer født i utlandet, er dette (med noen få unntak) eget fødeland. For personer født i Norge er det foreldrenes fødeland. I de tilfeller der foreldrene har ulikt fødeland, er det morens fødeland som blir valgt. Hvis ikke personen selv eller noen av foreldrene er utenlandsfødt, hentes landbakgrunn fra de første utenlandsfødte en treffer på i rekkefølgen mormor, morfar, farmor eller farfar.",
     "classification_uri": "https://www.ssb.no/en/klass/klassifikasjoner/91",
     "unit_types": [{
@@ -260,7 +261,7 @@ const val RENDERED_VIEW_EXAMPLE = """{
     $KLASS_REFERENCE_SUBJECT_FIELD_EXAMPLE
     ],
     "contains_special_categories_of_personal_data": true,
-    "variable_status": "PUBLISHED_INTERNAL",
+    "variable_status": "PUBLISHED_EXTERNAL",
     "measurement_type": {
         "reference_uri": "https://www.ssb.no/klass/klassifikasjoner/$MEASUREMENT_TYPE_KLASS_CODE",
         "code": "01",

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/publicapi/PublicController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/publicapi/PublicController.kt
@@ -63,8 +63,6 @@ class PublicController(
             description = ACCEPT_LANGUAGE_HEADER_PARAMETER_DESCRIPTION,
             examples = [
                 ExampleObject(name = "Date not specified", value = DEFAULT_LANGUAGE),
-                ExampleObject(name = "Specific date", value = DEFAULT_LANGUAGE),
-                ExampleObject(name = "Specific short_name", value = DEFAULT_LANGUAGE),
             ],
             required = false,
             allowEmptyValue = true,

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/publicapi/PublicController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/publicapi/PublicController.kt
@@ -46,6 +46,9 @@ class PublicController(
                         name = "Specific date",
                         value = LIST_OF_RENDERED_VIEWS_EXAMPLE,
                     ), ExampleObject(
+                        name = "Specific short_name",
+                        value = LIST_OF_RENDERED_VIEWS_EXAMPLE,
+                    ), ExampleObject(
                         name = "Date not specified",
                         value = EMPTY_LIST_EXAMPLE,
                     ),
@@ -60,6 +63,8 @@ class PublicController(
             description = ACCEPT_LANGUAGE_HEADER_PARAMETER_DESCRIPTION,
             examples = [
                 ExampleObject(name = "Date not specified", value = DEFAULT_LANGUAGE),
+                ExampleObject(name = "Specific date", value = DEFAULT_LANGUAGE),
+                ExampleObject(name = "Specific short_name", value = DEFAULT_LANGUAGE),
             ],
             required = false,
             allowEmptyValue = true,
@@ -171,6 +176,7 @@ class PublicController(
     @Get("/variable-definitions/{$VARIABLE_DEFINITION_ID_PATH_VARIABLE}/validity-periods")
     @Produces(MediaType.APPLICATION_JSON)
     @Tag(name = VALIDITY_PERIODS)
+    @NotFoundApiResponse
     @ApiResponse(
         responseCode = "200",
         content = [


### PR DESCRIPTION
- Almost the same description text as the internal, removed what is not relevant for external users
- Changed example status to be published external to not be confusing for external users
- Updated docs for list by shortname in public api