### PR TITLE
Document that a Keycloak token is supported

### DIFF
--- a/src/main/kotlin/no/ssb/metadata/vardef/Application.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/Application.kt
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.enums.SecuritySchemeType
 import io.swagger.v3.oas.annotations.info.Contact
 import io.swagger.v3.oas.annotations.info.Info
 import io.swagger.v3.oas.annotations.info.License
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.security.SecurityScheme
 import io.swagger.v3.oas.annotations.servers.Server
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -75,7 +76,7 @@ Variable Definitions are centralized definitions of concrete variables which are
 This API allows for creation, maintenance and access of Variable Definitions.
 
 ### Ownership
-Creation and maintenance of variables may only be performed by Statistics Norway employees representing a specific Dapla team, who are defined as the owners of a given Variable Definition. The team an owner represents must be specified when making a request through the `active_group` query parameter. All maintenance is to be performed by the owners, with no intervention from administrators.
+Creation and maintenance of variables may only be performed by Statistics Norway employees representing a specific Dapla team, who are defined as the owners of a given Variable Definition. In order to create variables, the single team an owner currently represents must be specified in the bearer token. This is currently only supported from the Dapla Lab platform. All maintenance is to be performed by the owners, with no intervention from administrators.
 
 ### Status
 All Variable Definitions have an associated status. The possible values for status are `DRAFT`, `PUBLISHED_INTERNAL` and `PUBLISHED_EXTERNAL`.
@@ -150,13 +151,25 @@ Validity Periods are versions with a period defined by a `valid_from` date and o
                 ),
                 Tag(name = DRAFT, description = "Create, update and delete variable definitions with DRAFT status."),
             ],
+            security = [
+                SecurityRequirement(name = SecuritySchemes.KEYCLOAK_TOKEN),
+                SecurityRequirement(name = SecuritySchemes.LABID_TOKEN),
+            ],
         ),
     securitySchemes = [
         SecurityScheme(
-            name = LABID_TOKEN_SCHEME,
+            name = SecuritySchemes.LABID_TOKEN,
             description =
                 "A token granted by Statistics Norway's LabID instance. May be obtained " +
-                    "from a <a href=https://lab.dapla.ssb.no>Dapla Lab</a> service.",
+                    "from a <a href=https://lab.dapla.ssb.no>Dapla Lab</a> service. Valid tokens may be granted all of the available roles.",
+            type = SecuritySchemeType.HTTP,
+            bearerFormat = "JWT",
+            scheme = "bearer",
+        ),
+        SecurityScheme(
+            name = SecuritySchemes.KEYCLOAK_TOKEN,
+            description =
+                "A token granted by Statistics Norway's Keycloak instance. The `aud` claim must include `vardef`. Valid tokens are by default granted the `VARIABLE_CONSUMER` role. In order to be assigned the `VARIABLE_OWNER` role, the token must contain the `dapla` claim with team details populated by <a href=https://github.com/statisticsnorway/keycloak-iac/blob/6d04379c4a311c039e71b2b4b0d60690c3de920c/pkl/GenericClient.pkl#L160>`DaplaUserinfoMapper`</a>. These tokens may not be granted the `VARIABLE_CREATOR` role.",
             type = SecuritySchemeType.HTTP,
             bearerFormat = "JWT",
             scheme = "bearer",

--- a/src/main/kotlin/no/ssb/metadata/vardef/constants/SecuritySchemes.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/constants/SecuritySchemes.kt
@@ -1,3 +1,8 @@
 package no.ssb.metadata.vardef.constants
 
-const val LABID_TOKEN_SCHEME = "labid_token"
+sealed class SecuritySchemes {
+    companion object {
+        const val KEYCLOAK_TOKEN = "keycloak_token"
+        const val LABID_TOKEN = "labid_token"
+    }
+}

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/PatchesController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/PatchesController.kt
@@ -27,8 +27,7 @@ import no.ssb.metadata.vardef.constants.*
 import no.ssb.metadata.vardef.models.CompleteView
 import no.ssb.metadata.vardef.models.CreatePatch
 import no.ssb.metadata.vardef.models.isPublished
-import no.ssb.metadata.vardef.security.VARIABLE_CONSUMER
-import no.ssb.metadata.vardef.security.VARIABLE_OWNER
+import no.ssb.metadata.vardef.security.Roles
 import no.ssb.metadata.vardef.services.PatchesService
 import no.ssb.metadata.vardef.services.ValidityPeriodsService
 import no.ssb.metadata.vardef.services.VariableDefinitionService
@@ -38,7 +37,7 @@ import java.time.LocalDate
 @Tag(name = PATCHES)
 @Validated
 @Controller("/variable-definitions/{$VARIABLE_DEFINITION_ID_PATH_VARIABLE}/patches")
-@Secured(VARIABLE_CONSUMER)
+@Secured(Roles.VARIABLE_CONSUMER)
 @ExecuteOn(TaskExecutors.BLOCKING)
 class PatchesController(
     private val validityPeriods: ValidityPeriodsService,
@@ -154,7 +153,7 @@ class PatchesController(
     @NotFoundApiResponse
     @BadRequestApiResponse
     @MethodNotAllowedApiResponse
-    @Secured(VARIABLE_OWNER)
+    @Secured(Roles.VARIABLE_OWNER)
     fun createPatch(
         @PathVariable(VARIABLE_DEFINITION_ID_PATH_VARIABLE)
         @Parameter(

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/PatchesController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/PatchesController.kt
@@ -39,7 +39,6 @@ import java.time.LocalDate
 @Validated
 @Controller("/variable-definitions/{$VARIABLE_DEFINITION_ID_PATH_VARIABLE}/patches")
 @Secured(VARIABLE_CONSUMER)
-@SecurityRequirement(name = LABID_TOKEN_SCHEME)
 @ExecuteOn(TaskExecutors.BLOCKING)
 class PatchesController(
     private val validityPeriods: ValidityPeriodsService,

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/PatchesController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/PatchesController.kt
@@ -17,7 +17,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import no.ssb.metadata.vardef.annotations.BadRequestApiResponse

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/ValidityPeriodsController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/ValidityPeriodsController.kt
@@ -15,7 +15,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import no.ssb.metadata.vardef.annotations.BadRequestApiResponse
@@ -25,15 +24,14 @@ import no.ssb.metadata.vardef.constants.*
 import no.ssb.metadata.vardef.models.CompleteView
 import no.ssb.metadata.vardef.models.CreateValidityPeriod
 import no.ssb.metadata.vardef.models.isPublished
-import no.ssb.metadata.vardef.security.VARIABLE_CONSUMER
-import no.ssb.metadata.vardef.security.VARIABLE_OWNER
+import no.ssb.metadata.vardef.security.Roles
 import no.ssb.metadata.vardef.services.ValidityPeriodsService
 
 @Tag(name = VALIDITY_PERIODS)
 @Validated
 @Controller("/variable-definitions/{$VARIABLE_DEFINITION_ID_PATH_VARIABLE}/validity-periods")
 @ExecuteOn(TaskExecutors.BLOCKING)
-@Secured(VARIABLE_CONSUMER)
+@Secured(Roles.VARIABLE_CONSUMER)
 class ValidityPeriodsController(
     private val validityPeriods: ValidityPeriodsService,
 ) {
@@ -60,7 +58,7 @@ class ValidityPeriodsController(
     @NotFoundApiResponse
     @BadRequestApiResponse
     @MethodNotAllowedApiResponse
-    @Secured(VARIABLE_OWNER)
+    @Secured(Roles.VARIABLE_OWNER)
     fun createValidityPeriod(
         @PathVariable(VARIABLE_DEFINITION_ID_PATH_VARIABLE)
         @Parameter(

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/ValidityPeriodsController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/ValidityPeriodsController.kt
@@ -34,7 +34,6 @@ import no.ssb.metadata.vardef.services.ValidityPeriodsService
 @Controller("/variable-definitions/{$VARIABLE_DEFINITION_ID_PATH_VARIABLE}/validity-periods")
 @ExecuteOn(TaskExecutors.BLOCKING)
 @Secured(VARIABLE_CONSUMER)
-@SecurityRequirement(name = LABID_TOKEN_SCHEME)
 class ValidityPeriodsController(
     private val validityPeriods: ValidityPeriodsService,
 ) {

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VarDokMigrationController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VarDokMigrationController.kt
@@ -51,7 +51,6 @@ private const val VARDOK_ID_PATH_PATTERN =
 @Validated
 @Controller("/vardok-migration")
 @Secured(VARIABLE_CONSUMER)
-@SecurityRequirement(name = LABID_TOKEN_SCHEME)
 @ExecuteOn(TaskExecutors.BLOCKING)
 class VarDokMigrationController(
     private val vardokService: VardokService,
@@ -83,6 +82,7 @@ class VarDokMigrationController(
             ],
     )
     @BadRequestApiResponse
+    @SecurityRequirement(name = SecuritySchemes.LABID_TOKEN)
     @Secured(VARIABLE_CREATOR)
     fun createVariableDefinitionFromVarDok(
         @Parameter(

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VarDokMigrationController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VarDokMigrationController.kt
@@ -29,8 +29,7 @@ import no.ssb.metadata.vardef.integrations.vardok.models.VardokNotFoundException
 import no.ssb.metadata.vardef.integrations.vardok.models.VardokVardefIdPairResponse
 import no.ssb.metadata.vardef.integrations.vardok.services.VardokService
 import no.ssb.metadata.vardef.models.CompleteView
-import no.ssb.metadata.vardef.security.VARIABLE_CONSUMER
-import no.ssb.metadata.vardef.security.VARIABLE_CREATOR
+import no.ssb.metadata.vardef.security.Roles
 import no.ssb.metadata.vardef.services.VariableDefinitionService
 import org.slf4j.LoggerFactory
 
@@ -50,7 +49,7 @@ private const val VARDOK_ID_PATH_PATTERN =
 @Tag(name = DATA_MIGRATION)
 @Validated
 @Controller("/vardok-migration")
-@Secured(VARIABLE_CONSUMER)
+@Secured(Roles.VARIABLE_CONSUMER)
 @ExecuteOn(TaskExecutors.BLOCKING)
 class VarDokMigrationController(
     private val vardokService: VardokService,
@@ -83,7 +82,7 @@ class VarDokMigrationController(
     )
     @BadRequestApiResponse
     @SecurityRequirement(name = SecuritySchemes.LABID_TOKEN)
-    @Secured(VARIABLE_CREATOR)
+    @Secured(Roles.VARIABLE_CREATOR)
     fun createVariableDefinitionFromVarDok(
         @Parameter(
             name = "vardok-id",

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionByIdController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionByIdController.kt
@@ -37,15 +37,14 @@ import no.ssb.metadata.vardef.models.UpdateDraft
 import no.ssb.metadata.vardef.models.UpdateDraftPatch
 import no.ssb.metadata.vardef.models.VariableStatus
 import no.ssb.metadata.vardef.models.isPublished
-import no.ssb.metadata.vardef.security.VARIABLE_CONSUMER
-import no.ssb.metadata.vardef.security.VARIABLE_OWNER
+import no.ssb.metadata.vardef.security.Roles
 import no.ssb.metadata.vardef.services.PatchesService
 import no.ssb.metadata.vardef.services.VariableDefinitionService
 import java.time.LocalDate
 
 @Validated
 @Controller("/variable-definitions/{$VARIABLE_DEFINITION_ID_PATH_VARIABLE}")
-@Secured(VARIABLE_CONSUMER)
+@Secured(Roles.VARIABLE_CONSUMER)
 @ExecuteOn(TaskExecutors.BLOCKING)
 class VariableDefinitionByIdController(
     private val vardef: VariableDefinitionService,
@@ -158,7 +157,7 @@ class VariableDefinitionByIdController(
     @MethodNotAllowedApiResponse
     @Status(HttpStatus.NO_CONTENT)
     @Delete
-    @Secured(VARIABLE_OWNER)
+    @Secured(Roles.VARIABLE_OWNER)
     fun deleteVariableDefinitionById(
         @PathVariable(VARIABLE_DEFINITION_ID_PATH_VARIABLE)
         @Parameter(
@@ -212,7 +211,7 @@ class VariableDefinitionByIdController(
     @MethodNotAllowedApiResponse
     @ConflictApiResponse
     @Patch
-    @Secured(VARIABLE_OWNER)
+    @Secured(Roles.VARIABLE_OWNER)
     fun updateVariableDefinitionById(
         @Parameter(
             description = ID_FIELD_DESCRIPTION,

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionByIdController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionByIdController.kt
@@ -20,7 +20,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
-import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.ConstraintViolationException
 import jakarta.validation.Validator

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionByIdController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionByIdController.kt
@@ -46,7 +46,6 @@ import java.time.LocalDate
 @Validated
 @Controller("/variable-definitions/{$VARIABLE_DEFINITION_ID_PATH_VARIABLE}")
 @Secured(VARIABLE_CONSUMER)
-@SecurityRequirement(name = LABID_TOKEN_SCHEME)
 @ExecuteOn(TaskExecutors.BLOCKING)
 class VariableDefinitionByIdController(
     private val vardef: VariableDefinitionService,

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionsController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionsController.kt
@@ -30,14 +30,13 @@ import no.ssb.metadata.vardef.models.CreateDraft
 import no.ssb.metadata.vardef.models.RenderedOrCompleteUnion
 import no.ssb.metadata.vardef.models.RenderedView
 import no.ssb.metadata.vardef.models.SupportedLanguages
-import no.ssb.metadata.vardef.security.VARIABLE_CONSUMER
-import no.ssb.metadata.vardef.security.VARIABLE_CREATOR
+import no.ssb.metadata.vardef.security.Roles
 import no.ssb.metadata.vardef.services.VariableDefinitionService
 import java.time.LocalDate
 
 @Validated
 @Controller("/variable-definitions")
-@Secured(VARIABLE_CONSUMER)
+@Secured(Roles.VARIABLE_CONSUMER)
 @ExecuteOn(TaskExecutors.BLOCKING)
 class VariableDefinitionsController(
     private val vardef: VariableDefinitionService,
@@ -155,7 +154,7 @@ class VariableDefinitionsController(
     @BadRequestApiResponse
     @ConflictApiResponse
     @SecurityRequirement(name = SecuritySchemes.LABID_TOKEN)
-    @Secured(VARIABLE_CREATOR)
+    @Secured(Roles.VARIABLE_CREATOR)
     fun createVariableDefinition(
         @RequestBody(
             content = [

--- a/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionsController.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/controllers/internalapi/VariableDefinitionsController.kt
@@ -38,7 +38,6 @@ import java.time.LocalDate
 @Validated
 @Controller("/variable-definitions")
 @Secured(VARIABLE_CONSUMER)
-@SecurityRequirement(name = LABID_TOKEN_SCHEME)
 @ExecuteOn(TaskExecutors.BLOCKING)
 class VariableDefinitionsController(
     private val vardef: VariableDefinitionService,
@@ -155,6 +154,7 @@ class VariableDefinitionsController(
     )
     @BadRequestApiResponse
     @ConflictApiResponse
+    @SecurityRequirement(name = SecuritySchemes.LABID_TOKEN)
     @Secured(VARIABLE_CREATOR)
     fun createVariableDefinition(
         @RequestBody(

--- a/src/main/kotlin/no/ssb/metadata/vardef/security/KeycloakTokenValidator.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/security/KeycloakTokenValidator.kt
@@ -10,6 +10,7 @@ import io.micronaut.security.token.jwt.validator.ReactiveJsonWebTokenValidator
 import jakarta.inject.Inject
 import no.ssb.metadata.vardef.constants.SSB_EMAIL
 import no.ssb.metadata.vardef.exceptions.InvalidActiveGroupException
+import no.ssb.metadata.vardef.security.Roles
 import org.reactivestreams.Publisher
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
@@ -41,7 +42,7 @@ class KeycloakTokenValidator<R : HttpRequest<*>> : ReactiveJsonWebTokenValidator
     private fun getUsername(claims: JWTClaimsSet): String? = claims.subject?.plus(SSB_EMAIL)
 
     /**
-     * @return `true` if the principal can be assigned the [VARIABLE_OWNER] role.
+     * @return `true` if the principal can be assigned the [Roles.VARIABLE_OWNER] role.
      */
     private fun isVariableOwner(claimsSet: JWTClaimsSet): Boolean =
         daplaClaim in claimsSet.claims &&
@@ -55,7 +56,7 @@ class KeycloakTokenValidator<R : HttpRequest<*>> : ReactiveJsonWebTokenValidator
      * The token is expected to have claims added by `oidc-dapla-userinfo-mapper` with the
      * `nested_teams` config set to `false`. Ref <https://github.com/statisticsnorway/keycloak-iac/blob/0c3362d7d31b9d34780cd88492c5fcd963fc4ef2/pkl/GenericClient.pkl#L182>
      *
-     * By default, authenticated users receive the [VARIABLE_CONSUMER] role. If they fulfill the
+     * By default, authenticated users receive the [Roles.VARIABLE_CONSUMER] role. If they fulfill the
      * requirements then they receive other roles in addition.
      *
      * @param claimsSet the parsed JWT token
@@ -64,14 +65,14 @@ class KeycloakTokenValidator<R : HttpRequest<*>> : ReactiveJsonWebTokenValidator
      */
     private fun assignRoles(claimsSet: JWTClaimsSet): Set<String> {
         // If we arrive here the principal is authenticated. Give all principals a default role.
-        val roles = mutableSetOf(VARIABLE_CONSUMER)
+        val roles = mutableSetOf(Roles.VARIABLE_CONSUMER)
         val username = getUsername(claimsSet)
 
         logger.debug("Assigning roles for user=$username")
 
         if (isVariableOwner(claimsSet)) {
-            roles.add(VARIABLE_OWNER)
-            logger.debug("User=$username assigned role=$VARIABLE_OWNER")
+            roles.add(Roles.VARIABLE_OWNER)
+            logger.debug("User={} assigned role={}", username, Roles.VARIABLE_OWNER)
         }
 
         logger.info("User=$username assigned roles=$roles")

--- a/src/main/kotlin/no/ssb/metadata/vardef/security/LabIdTokenValidator.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/security/LabIdTokenValidator.kt
@@ -12,6 +12,7 @@ import no.ssb.metadata.vardef.constants.ACTIVE_GROUP
 import no.ssb.metadata.vardef.constants.SSB_EMAIL
 import no.ssb.metadata.vardef.exceptions.InvalidActiveGroupException
 import no.ssb.metadata.vardef.integrations.dapla.services.DaplaTeamService
+import no.ssb.metadata.vardef.security.Roles
 import org.reactivestreams.Publisher
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
@@ -44,7 +45,7 @@ class LabIdTokenValidator<R : HttpRequest<*>> : ReactiveJsonWebTokenValidator<JW
     private fun getUsername(claimsSet: JWTClaimsSet): String? = claimsSet.subject?.plus(SSB_EMAIL)
 
     /**
-     * @return `true` if the principal can be assigned the [VARIABLE_OWNER] role.
+     * @return `true` if the principal can be assigned the [Roles.VARIABLE_OWNER] role.
      */
     private fun isVariableOwner(claimsSet: JWTClaimsSet): Boolean =
         activeGroupClaim in claimsSet.claims &&
@@ -52,7 +53,7 @@ class LabIdTokenValidator<R : HttpRequest<*>> : ReactiveJsonWebTokenValidator<JW
             getDaplaGroups(claimsSet).isNotEmpty()
 
     /**
-     * @return `true` if the principal can be assigned the [VARIABLE_CREATOR] role.
+     * @return `true` if the principal can be assigned the [Roles.VARIABLE_CREATOR] role.
      */
     private fun isVariableCreator(
         activeGroup: String?,
@@ -69,7 +70,7 @@ class LabIdTokenValidator<R : HttpRequest<*>> : ReactiveJsonWebTokenValidator<JW
      *
      * The roles are assigned based on claims in the token.
      *
-     * By default, authenticated users receive the [VARIABLE_CONSUMER] role. If they fulfill the
+     * By default, authenticated users receive the [Roles.VARIABLE_CONSUMER] role. If they fulfill the
      * requirements then they receive other roles in addition.
      *
      * @param claimsSet the claims from the JWT token
@@ -79,19 +80,19 @@ class LabIdTokenValidator<R : HttpRequest<*>> : ReactiveJsonWebTokenValidator<JW
     private fun assignRoles(claimsSet: JWTClaimsSet): Set<String> {
         // If we arrive here the principal is authenticated. Give all principals a default role.
 
-        val roles = mutableSetOf(VARIABLE_CONSUMER)
+        val roles = mutableSetOf(Roles.VARIABLE_CONSUMER)
         val username = getUsername(claimsSet)
         val activeGroup = getActiveGroup(claimsSet)
 
         logger.debug("Assigning roles for user=$username activeGroup=$activeGroup")
 
         if (isVariableOwner(claimsSet)) {
-            roles.add(VARIABLE_OWNER)
-            logger.debug("User=$username assigned role=$VARIABLE_OWNER")
+            roles.add(Roles.VARIABLE_OWNER)
+            logger.debug("User={} assigned role={}", username, Roles.VARIABLE_OWNER)
         }
         if (isVariableCreator(activeGroup, claimsSet)) {
-            roles.add(VARIABLE_CREATOR)
-            logger.debug("User=$username assigned role=$VARIABLE_CREATOR")
+            roles.add(Roles.VARIABLE_CREATOR)
+            logger.debug("User={} assigned role={}", username, Roles.VARIABLE_CREATOR)
         }
 
         logger.info("User=$username assigned roles=$roles")

--- a/src/main/kotlin/no/ssb/metadata/vardef/security/Roles.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/security/Roles.kt
@@ -1,5 +1,9 @@
 package no.ssb.metadata.vardef.security
 
-const val VARIABLE_CREATOR = "VARIABLE_CREATOR"
-const val VARIABLE_OWNER = "VARIABLE_OWNER"
-const val VARIABLE_CONSUMER = "VARIABLE_CONSUMER"
+sealed class Roles {
+    companion object {
+        const val VARIABLE_CREATOR = "VARIABLE_CREATOR"
+        const val VARIABLE_OWNER = "VARIABLE_OWNER"
+        const val VARIABLE_CONSUMER = "VARIABLE_CONSUMER"
+    }
+}

--- a/src/main/kotlin/no/ssb/metadata/vardef/security/VariableOwnerSecurityRule.kt
+++ b/src/main/kotlin/no/ssb/metadata/vardef/security/VariableOwnerSecurityRule.kt
@@ -26,7 +26,7 @@ import reactor.core.scheduler.Schedulers
 /**
  * Variable Owner security rule
  *
- * The [VARIABLE_OWNER] role is required on operations where a principal _modifies_ an existing resource. Due to our
+ * The [Roles.VARIABLE_OWNER] role is required on operations where a principal _modifies_ an existing resource. Due to our
  * authentication architecture, the bearer token does not contain information about which concrete resources the
  * principal has access to.
  *
@@ -57,9 +57,9 @@ class VariableOwnerSecurityRule(
     override fun getOrder(): Int = SecuredAnnotationRule.ORDER - 50
 
     /**
-     * Does the operation require the [VARIABLE_OWNER] role.
+     * Does the operation require the [Roles.VARIABLE_OWNER] role.
      *
-     * Here we're checking whether the operation is annotated with the [Secured] annotation, with [VARIABLE_OWNER]
+     * Here we're checking whether the operation is annotated with the [Secured] annotation, with [Roles.VARIABLE_OWNER]
      * supplied as one of the values.
      *
      * @param routeMatch the [RouteMatch] from Micronaut.
@@ -72,7 +72,7 @@ class VariableOwnerSecurityRule(
                 val optionalValue = routeMatch.getValue(Secured::class.java, Array<String>::class.java)
                 if (optionalValue.isPresent) {
                     val requiredRoles: List<String> = optionalValue.get().toList()
-                    return VARIABLE_OWNER in requiredRoles
+                    return Roles.VARIABLE_OWNER in requiredRoles
                 }
             }
         }
@@ -118,13 +118,13 @@ class VariableOwnerSecurityRule(
                 // Get active group from authentication attributes
                 val activeGroup = authentication.attributes[ACTIVE_GROUP] as String?
                 if (activeGroup == null) {
-                    logger.info("No active group found in request or authentication claims. Request: $request")
+                    logger.info("No active group found in request or authentication claims. Request: {}", request)
                     return@map false
                 }
                 variableDefinitionService.groupIsOwner(activeGroup, definitionId)
             }.handle { isOwner, sink ->
-                if (VARIABLE_OWNER !in authentication.roles) {
-                    logger.info("Rejected access. Principal does not have $VARIABLE_OWNER role. Request: $request")
+                if (Roles.VARIABLE_OWNER !in authentication.roles) {
+                    logger.info("Rejected access. Principal does not have {} role. Request: {}", Roles.VARIABLE_OWNER, request)
                     sink.next(SecurityRuleResult.REJECTED)
                     sink.complete()
                 } else {
@@ -133,13 +133,13 @@ class VariableOwnerSecurityRule(
                         sink.next(SecurityRuleResult.ALLOWED)
                         sink.complete()
                     } else {
-                        logger.info("Rejected access. Principal does not own the requested resource. Request: $request")
+                        logger.info("Rejected access. Principal does not own the requested resource. Request: {}", request)
                         sink.next(SecurityRuleResult.REJECTED)
                         sink.complete()
                     }
                 }
             }.switchIfEmpty(Mono.just(SecurityRuleResult.UNKNOWN))
-            .doOnError { logger.error("Error while authorizing for $VARIABLE_OWNER for $request", it) }
+            .doOnError { logger.error("Error while authorizing for {} for Request: {}", Roles.VARIABLE_OWNER, request, it) }
             .onErrorReturn(SecurityRuleResult.UNKNOWN)
     }
 }

--- a/src/test/kotlin/no/ssb/metadata/vardef/security/KeycloakTokenValidatorTest.kt
+++ b/src/test/kotlin/no/ssb/metadata/vardef/security/KeycloakTokenValidatorTest.kt
@@ -38,7 +38,7 @@ class KeycloakTokenValidatorTest {
                         HttpRequest.POST("/variable-definitions", ""),
                     ),
                 ).block()
-        assertThat(auth?.roles).containsExactly(VARIABLE_CONSUMER)
+        assertThat(auth?.roles).containsExactly(Roles.VARIABLE_CONSUMER)
         assertThat(auth?.name).isEqualTo(TEST_USER)
     }
 
@@ -80,7 +80,7 @@ class KeycloakTokenValidatorTest {
                     ),
                 ).block()
 
-        assertThat(auth?.roles).containsExactly(VARIABLE_CONSUMER)
+        assertThat(auth?.roles).containsExactly(Roles.VARIABLE_CONSUMER)
     }
 
     @Test

--- a/src/test/kotlin/no/ssb/metadata/vardef/security/LabIdTokenValidatorTest.kt
+++ b/src/test/kotlin/no/ssb/metadata/vardef/security/LabIdTokenValidatorTest.kt
@@ -38,7 +38,7 @@ class LabIdTokenValidatorTest {
                         HttpRequest.POST("/variable-definitions", ""),
                     ),
                 ).block()
-        assertThat(auth?.roles).containsExactly(VARIABLE_CONSUMER, VARIABLE_OWNER, VARIABLE_CREATOR)
+        assertThat(auth?.roles).containsExactly(Roles.VARIABLE_CONSUMER, Roles.VARIABLE_OWNER, Roles.VARIABLE_CREATOR)
         assertThat(auth?.name).isEqualTo(TEST_USER)
     }
 
@@ -80,7 +80,7 @@ class LabIdTokenValidatorTest {
                     ),
                 ).block()
 
-        assertThat(auth?.roles).containsExactly(VARIABLE_CONSUMER)
+        assertThat(auth?.roles).containsExactly(Roles.VARIABLE_CONSUMER)
     }
 
     @Test

--- a/src/test/kotlin/no/ssb/metadata/vardef/security/RoleBasedAccessControlTest.kt
+++ b/src/test/kotlin/no/ssb/metadata/vardef/security/RoleBasedAccessControlTest.kt
@@ -4,6 +4,7 @@ import io.micronaut.http.HttpStatus
 import io.restassured.http.ContentType
 import io.restassured.http.Method
 import io.restassured.specification.RequestSpecification
+import no.ssb.metadata.vardef.security.Roles
 import no.ssb.metadata.vardef.utils.*
 import org.hamcrest.Matchers.*
 import org.json.JSONObject
@@ -166,9 +167,9 @@ class RoleBasedAccessControlTest : BaseVardefTest() {
 
     companion object {
         /**
-         * Tests cases for operations requiring the [VARIABLE_CREATOR] role.
+         * Tests cases for operations requiring [Roles.VARIABLE_CREATOR].
          *
-         * All operations annotated with `@Secured(VARIABLE_CREATOR)` should be included here.
+         * All operations annotated with `@Secured(Roles.VARIABLE_CREATOR)` should be included here.
          */
         @JvmStatic
         fun variableCreatorOperations(): Stream<Arguments> =
@@ -186,9 +187,9 @@ class RoleBasedAccessControlTest : BaseVardefTest() {
             )
 
         /**
-         * Tests cases for operations requiring the [VARIABLE_OWNER] role.
+         * Tests cases for operations requiring the [Roles.VARIABLE_OWNER] role.
          *
-         * All operations annotated with `@Secured(VARIABLE_OWNER)` should be included here.
+         * All operations annotated with `@Secured(Roles.VARIABLE_OWNER)` should be included here.
          */
         @JvmStatic
         fun variableOwnerOperations(): Stream<Arguments> =
@@ -237,9 +238,9 @@ class RoleBasedAccessControlTest : BaseVardefTest() {
             )
 
         /**
-         * Tests cases for operations requiring the [VARIABLE_CONSUMER] role.
+         * Tests cases for operations requiring the [Roles.VARIABLE_CONSUMER] role.
          *
-         * All operations annotated with `@Secured(VARIABLE_CONSUMER)` should be included here.
+         * All operations annotated with `@Secured(Roles.VARIABLE_CONSUMER)` should be included here.
          * Only operations with the HTTP method GET should have this role.
          */
         @JvmStatic


### PR DESCRIPTION
The API documentation was outdated, a Keycloak token is supported in the majority of cases.

Also use a sealed class to group related constants. We can't use an enum for these because Annotations require a constant value which is known at compile time.
