### PR TITLE
Add monthly Docker Dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,3 +18,9 @@ updates:
       github-action-dependencies:
         patterns:
           - "*"
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 7

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("jacoco")
 }
 
-version = "0.4.1"
+version = "0.4.2"
 group = "no.ssb.metadata.vardef"
 
 val kotlinVersion: String = libs.versions.kotlin.toString()


### PR DESCRIPTION
## What
- add Dependabot docker ecosystem updates in the repository root
- run monthly schedule
- set cooldown default-days to 7

## Why
Keep Docker base image dependencies updated on a regular cadence with a cooldown period.