### PR TITLE
fix: bump jackson-databind to 3.1.4 for CVE-2026-54512

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,8 @@ dependencies {
         implementation("org.codehaus.plexus:plexus-utils:4.0.3")
         implementation("org.apache.commons:commons-lang3:3.18.0")
         implementation("commons-codec:commons-codec:1.13")
+        // Fix CVE-2026-54512 and related CVEs (HIGH severity) in jackson-databind 3.x
+        implementation("tools.jackson.core:jackson-databind:3.1.4")
     }
 }
 


### PR DESCRIPTION
## What
- Add an explicit dependency constraint in `build.gradle.kts` for `tools.jackson.core:jackson-databind:3.1.4`
- Keep Micronaut-managed transitive dependencies, but pin patched jackson-databind version

## Why
- Fixes CVE-2026-54512 (HIGH) and related jackson-databind 3.1.3 advisories

## Verification
- Checked dependency resolution in `compileClasspath` and confirmed `tools.jackson.core:jackson-databind:3.1.4` is selected