### PR TITLE
Replace outdated dependency name

### DIFF
--- a/backstage.yaml
+++ b/backstage.yaml
@@ -25,7 +25,7 @@ spec:
     - vardef-api
   consumesApis:
     - klass-api
-    - dapla-team-api
+    - dapla-api
   dependsOn:
     - resource:metadata-mongodb
     - component:vardok


### PR DESCRIPTION
Vardef dependence on `dapla-api`, not `dapla-team-api`.
