### PR TITLE
Fix reported dependency vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN chmod +x ./gradlew
 COPY src src
 RUN ./gradlew shadowJar --no-daemon
 
-FROM gcr.io/distroless/java25-debian13
+FROM gcr.io/distroless/java25-debian13:latest
 WORKDIR /app
 COPY --from=builder /app/build/libs/*-all.jar app.jar
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     aotPlugins(platform(libs.micronaut.platform))
 
     constraints {
+        implementation("io.netty:netty-bom:4.2.17.Final")
         implementation("org.codehaus.plexus:plexus-utils:4.0.3")
         implementation("org.apache.commons:commons-lang3:3.18.0")
         implementation("commons-codec:commons-codec:1.13")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
         implementation("org.apache.commons:commons-lang3:3.18.0")
         implementation("commons-codec:commons-codec:1.13")
         // Fix CVE-2026-54512 and related CVEs (HIGH severity) in jackson-databind 3.x
-        implementation("tools.jackson.core:jackson-databind:3.1.4")
+        implementation("tools.jackson.core:jackson-databind:3.1.5")
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@
 
 [versions]
 assertj = "3.27.7"
-jackson = "2.22.0"
+jackson = "2.22.2"
 json = "20260522"
 junit = "6.1.0"
 kotlin = "2.4.0"


### PR DESCRIPTION
Update Netty and Jackson to patched releases addressing the reported CVEs.